### PR TITLE
replaced setuid bit for mtr with net_raw capability

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -147,8 +147,9 @@
  +capabilities cap_net_raw=ep
 /usr/bin/ping6                                          root:root         4755
  +capabilities cap_net_raw=ep
-# mtr is linked against ncurses. For dialout only.
-/usr/sbin/mtr                                           root:dialout      4750
+#no need for SUID, net_raw capability is enough
+/usr/sbin/mtr                                           root:root         0755
+ +capabilities cap_net_raw=ep
 /usr/bin/rcp                                            root:root         4755
 /usr/bin/rlogin                                         root:root         4755
 /usr/bin/rsh                                            root:root         4755

--- a/permissions.secure
+++ b/permissions.secure
@@ -186,7 +186,8 @@
 /usr/bin/ping6                                          root:root         4755
  +capabilities cap_net_raw=ep
 # mtr is linked against ncurses. no suid bit, for root only:
-/usr/sbin/mtr                                           root:dialout      0755
+/usr/sbin/mtr                                           root:root         0755
+ +capabilities cap_net_raw=ep
 /usr/bin/rcp                                            root:root         4755
 /usr/bin/rlogin                                         root:root         4755
 /usr/bin/rsh                                            root:root         4755


### PR DESCRIPTION
Allows to run MTR as unprivileged user.
