### PR TITLE
typos in man-pgaes

### DIFF
--- a/chkstat.8
+++ b/chkstat.8
@@ -26,7 +26,7 @@ The program
 is a tool to check and set file permissions.
 .PP
 chkstat can either operate in system mode or on individually
-specified permission files. In system mode /etc/permissions/security
+specified permission files. In system mode, \fI/etc/sysconfig/security\fR
 determines which level to use and whether to actually apply
 permission changes.
 .PP
@@ -53,7 +53,7 @@ Omit printing the output header lines.
 .TP
 .IR \-\-fscaps,\ \-\-no\-fscaps
 Enable or disable use of fscaps. In system mode the setting of
-PERMISSIONS_FSCAPS determines whether fscaps are on or off when this
+\fIPERMISSIONS_FSCAPS\fR determines whether fscaps are on or off when this
 option is not set.
 .TP
 .IR \-\-examine\ file

--- a/permissions.5
+++ b/permissions.5
@@ -21,7 +21,7 @@ end with a slash\.
 \- The third column specifies the file mode\.
 .br
 \- The special value \fB+capabilities\fR in the first column extends
-the information of the previous line with with file capabilites.
+the information of the previous line with file capabilites.
 .br
 .SH "FILES"
 .sp
@@ -44,5 +44,5 @@ chkstat(8)
 Written by Ludwig Nussel
 .sp
 .SH "REPORTING BUGS"
-Report bugs to https://bugzilla\.novell\.com/
+Report bugs to https://bugzilla\.suse\.com/
 .sp


### PR DESCRIPTION
Nevertheless the man pages should probably be corrected more, for example CHECK_PERMISSIONS sysconfig variable does not seem to exist.