### PR TITLE
Allow setuid root for singularity (group only) bsc#1028304

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -346,6 +346,7 @@
 /usr/lib/singularity/bin/action-suid			root:singularity  4750
 /usr/lib/singularity/bin/export-suid			root:singularity  4750
 /usr/lib/singularity/bin/import-suid			root:singularity  4750
+/usr/lib/singularity/bin/start-suid			root:singularity  4750
 
 #
 # XXX: / -> /usr merge and sbin -> bin merge

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -363,6 +363,7 @@
 /usr/lib/singularity/bin/action-suid			root:singularity  0750
 /usr/lib/singularity/bin/export-suid			root:singularity  0750
 /usr/lib/singularity/bin/import-suid			root:singularity  0750
+/usr/lib/singularity/bin/start-suid			root:singularity  0750
 
 #
 # XXX: / -> /usr merge and sbin -> bin merge

--- a/permissions.secure
+++ b/permissions.secure
@@ -386,6 +386,7 @@
 /usr/lib/singularity/bin/action-suid			root:singularity  4750
 /usr/lib/singularity/bin/export-suid			root:singularity  4750
 /usr/lib/singularity/bin/import-suid			root:singularity  4750
+/usr/lib/singularity/bin/start-suid			root:singularity  4750
 
 #
 # XXX: / -> /usr merge and sbin -> bin merge


### PR DESCRIPTION
In preparation for singularity 2.4 add /usr/lib/singularity/bin/start-suid to list.

Signed-off-by: Egbert Eich <eich@suse.com>