### PR TITLE
Capabilities for usage of Wireshark for non-root

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -336,8 +336,9 @@
 # ecryptfs-utils (bnc#740110)
 /sbin/mount.ecryptfs_private				root:root         4755
 
-# wireshark (not yet)
-/usr/bin/dumpcap					root:root	  0755
+# wireshark (bsc#957624)
+/usr/bin/dumpcap					root:wireshark	  0755
+ +capabilities cap_net_raw,cap_net_admin=ep
 
 # singularity (bsc#1028304)
 /usr/lib/singularity/bin/expand-suid			root:singularity  4750

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -353,7 +353,7 @@
 # ecryptfs-utils (bnc#740110)
 /sbin/mount.ecryptfs_private                            root:root         0755
 
-# wireshark (not yet)
+# wireshark (bsc#957624)
 /usr/bin/dumpcap					root:root	  0755
 
 # singularity (bsc#1028304)

--- a/permissions.secure
+++ b/permissions.secure
@@ -376,8 +376,9 @@
 # ecryptfs-utils (bnc#740110)
 /sbin/mount.ecryptfs_private                            root:root         0755
 
-# wireshark (not yet)
-/usr/bin/dumpcap					root:root	  0755
+# wireshark (bsc#957624)
+/usr/bin/dumpcap					root:wireshark	  0750
+ +capabilities cap_net_raw,cap_net_admin=ep
 
 # singularity (bsc#1028304)
 /usr/lib/singularity/bin/expand-suid			root:singularity  4750


### PR DESCRIPTION
Capabilities for usage of Wireshark for non-root
easy: all users, for the desktop out of the box experience
secure: members of wireshark group
paranoid: no capabilities

[bsc#957624](https://bugzilla.opensuse.org/show_bug.cgi?id=957624)