### PR TITLE
iputils: Add capability permissions for clockdiff

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -115,6 +115,8 @@
 #
 # networking (need root for the privileged socket)
 #
+/usr/bin/clockdiff                                      root:root         0755
+ +capabilities cap_net_raw=p
 /usr/bin/ping                                           root:root         0755
  +capabilities cap_net_raw=ep
 /usr/bin/ping6                                          root:root         0755

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -131,6 +131,7 @@
 #
 # networking (need root for the privileged socket)
 #
+/usr/bin/clockdiff                                      root:root         0755
 /usr/bin/ping                                           root:root         0755
 /usr/bin/ping6                                          root:root         0755
 # mtr is linked against ncurses.

--- a/permissions.secure
+++ b/permissions.secure
@@ -156,6 +156,8 @@
 #
 # networking (need root for the privileged socket)
 #
+/usr/bin/clockdiff                                      root:root         0755
+ +capabilities cap_net_raw=p
 /usr/bin/ping                                           root:root         0755
  +capabilities cap_net_raw=ep
 /usr/bin/ping6                                          root:root         0755


### PR DESCRIPTION
permissions are the same as for ping.

NOTE: originally I wanted to add also capabilities arping,
but it could be used for ARP poisoning attacks.

Fixes: boo#1140994

Signed-off-by: Petr Vorel <pvorel@suse.cz>