### PR TITLE
Move permissions and permissions.* except .local to /usr/share/permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DESTDIR=
 LDLIBS=-lcap
 prefix=/usr
 sysconfdir=/etc
+permissionsdir=/usr/share/permissions
 bindir=$(prefix)/bin
 fillupdir=/var/adm/fillup-templates
 datadir=$(prefix)/share
@@ -21,15 +22,16 @@ CPPFLAGS += -DFSCAPS_DEFAULT_ENABLED=$(FSCAPS_DEFAULT_ENABLED)
 all: src/chkstat
 
 install: all
-	@for i in $(bindir) $(man8dir) $(man5dir) $(fillupdir) $(sysconfdir) $(zypp_commit_plugins); \
+	@for i in $(bindir) $(man8dir) $(man5dir) $(fillupdir) $(sysconfdir) $(permissionsdir) $(zypp_commit_plugins); \
 		do install -d -m 755 $(DESTDIR)$$i; done
 	@install -m 755 src/chkstat $(DESTDIR)$(bindir)
 	@install -m 644 man/chkstat.8 $(DESTDIR)$(man8dir)
 	@install -m 644 man/permissions.5 $(DESTDIR)$(man5dir)
 	@install -m 644 etc/sysconfig.security $(DESTDIR)$(fillupdir)
 	@install -m 755 zypper-plugin/permissions.py $(DESTDIR)$(zypp_commit_plugins)
-	@for i in etc/permissions* profiles/permissions.*; \
-		do install -m 644 $$i $(DESTDIR)$(sysconfdir); done
+	@for i in etc/permissions profiles/permissions.*; \
+		do install -m 644 $$i $(DESTDIR)$(permissionsdir); done
+	@install -m 644 etc/permissions.local $(DESTDIR)$(sysconfdir)
 
 
 clean:

--- a/etc/permissions
+++ b/etc/permissions
@@ -1,4 +1,4 @@
-# /etc/permissions
+# /usr/share/permissions/permissions
 #
 # Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.
 # Copyright (c) 2011 SUSE Linux Products GmbH Nuernberg, Germany.
@@ -9,10 +9,10 @@
 # to check or set the modes and ownerships of files and directories in the installation.
 #
 # There is a set of files with similar meaning in a SUSE installation:
-# /etc/permissions  (This file)
-# /etc/permissions.easy
-# /etc/permissions.secure
-# /etc/permissions.paranoid
+# /usr/share/permissions/permissions  (This file)
+# /usr/share/permissions/permissions.easy
+# /usr/share/permissions/permissions.secure
+# /usr/share/permissions/permissions.paranoid
 # /etc/permissions.local
 # Please see the respective files for their meaning.
 #
@@ -28,11 +28,11 @@
 # /etc/sysconfig/security to determine which security level to
 # apply.
 # In addition to the central files listed above the directory
-# /etc/permissions.d/ can contain permission files that belong to
-# the packages they modify file modes for. These permission files
-# are to switch between conflicting file modes of the same file
-# paths in different packages (popular example: sendmail and
-# postfix, path /usr/sbin/sendmail).
+# /usr/share/permissions/permissions.d/ can contain permission files
+# that belong to the packages they modify file modes for. These 
+# permission files are to switch between conflicting file modes of
+# the same file paths in different packages (popular example:
+# sendmail and postfix, path /usr/sbin/sendmail).
 
 #
 # root directories:

--- a/man/chkstat.8
+++ b/man/chkstat.8
@@ -69,9 +69,10 @@ Check files relative to the specified directory.
 .PP
 .SH EXAMPLES
 .PP
-.B chkstat --set /etc/permissions /etc/permissions.secure
+.B chkstat --set /usr/share/permissions/permissions /usr/share/permissions/permissions.secure
 .PP
-parses the files /etc/permissions and /etc/permissions and sets the
+parses the files /usr/share/permissions/permissions and 
+/usr/share/permissions/permissions and sets the
 access mode and the user- and group memberships for each file listed.
 .PP
 .B chkstat --system /bin/ping

--- a/man/permissions.5
+++ b/man/permissions.5
@@ -9,7 +9,7 @@ permission - default permission settings
 The chkstat program sets permissions and ownerships according to the
 permission files\.
 .SH "DESCRIPTION"
-\- The files /etc/permissions\.* are line based and space delimited\.
+\- The files /usr/share/permissions/permissions\.* are line based and space delimited\.
 .br
 \- Lines starting with # are comments\.
 .br
@@ -25,15 +25,15 @@ the information of the previous line with file capabilites.
 .br
 .SH "FILES"
 .sp
-/etc/permissions
+/usr/share/permissions/permissions
 .br
-/etc/permissions\.easy
+/usr/share/permissions/permissions\.easy
 .br
-/etc/permissions\.secure
+/usr/share/permissions/permissions\.secure
 .br
-/etc/permissions\.paranoid
+/usr/share/permissions/permissions\.paranoid
 .br
-/etc/permissions\.d/*
+/usr/share/permissions/permissions\.d/*
 .br
 /etc/permissions\.local
 .br

--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -4,10 +4,11 @@
 # Author: Roman Drahtmueller <draht@suse.de>, 2001
 #
 # 
-# See /etc/permissions for general hints on how to use this file.
+# See /usr/share/permissions/permissions for general hints on how to use this
+# file.
 #
-# /etc/permissions.easy is set up for the use in a standalone and single-user
-# installation to make things "work" out-of-the box.
+# /usr/share/permissions/permissions.easy is set up for the use in a
+# standalone and single-user installation to make things "work" out-of-the box.
 # Some of the settings might be considered somewhat lax from the security
 # standpoint. These aspects are handled differently in the permissions.secure
 # file.

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -1,14 +1,16 @@
-# /etc/permissions.paranoid
+# /usr/share/permissions/permissions.paranoid
 #
 # Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
 #
 # Author: Roman Drahtmueller <draht@suse.de>, 2001
 #
 # 
-# See /etc/permissions for general hints on how to use this file.
+# See /usr/share/permissions/permissions for general hints on how to use
+# this file.
 #
-# /etc/permissions.paranoid is NOT designed to be used in a single-user as
-# well as a multi-user installation, be it networked or not.
+# /usr/share/permissions/permissions.paranoid is NOT designed to be used
+# in a single-user as well as a multi-user installation, be it networked
+# or not.
 #
 # Derived from /etc/permissions.secure, it has _all_ sgid and suid bits
 # cleared - therefore, the system is probably not useable for non-privileged

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -1,16 +1,17 @@
-# /etc/permissions.secure
+# /usr/share/permissions/permissions.secure
 #
 # Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
 #
 # Author: Roman Drahtmueller <draht@suse.de>, 2001
 #
 # 
-# See /etc/permissions for general hints on how to use this file.
+# See /usr/share/permissions/permissions for general hints on how to use
+# this file.
 #
-# /etc/permissions.secure is designed for the use in a multi-user and
-# networked installation. Most privileged file modes are disabled here.
-# Many programs that still have their suid- or sgid-modes have had their
-# security problems in the past already.
+# /usr/share/permissions/permissions.secure is designed for the use in a
+# multi-user and networked installation. Most privileged file modes are
+# disabled here. Many programs that still have their suid- or sgid-modes
+# have had their security problems in the past already.
 # The primary target of this configuration is to make the basic things
 # such as changing passwords, the basic networking programs as well as
 # some of the all-day work programs properly function for the unprivileged

--- a/src/chkstat.c
+++ b/src/chkstat.c
@@ -4,7 +4,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -310,33 +310,12 @@ compare(const void* a, const void* b)
 }
 
 static void
-collect_permfiles()
+read_permissions_d(const char *directory)
 {
   size_t i;
-  DIR* dir;
+  DIR *dir;
 
-  ensure_array((void**)&permfiles, &npermfiles);
-  // 1. central fixed permissions file
-  permfiles[npermfiles++] = strdup("/etc/permissions");
-
-  // 2. central easy, secure paranoid as those are defined by SUSE
-  for (i = 0; i < nlevel; ++i)
-    {
-      if (!strcmp(level[i], "easy")
-              || !strcmp(level[i], "secure")
-              || !strcmp(level[i], "paranoid"))
-        {
-          char fn[4096];
-          snprintf(fn, sizeof(fn), "/etc/permissions.%s", level[i]);
-          if (access(fn, R_OK) == 0)
-            {
-              ensure_array((void**)&permfiles, &npermfiles);
-              permfiles[npermfiles++] = strdup(fn);
-            }
-        }
-    }
-  // 3. package specific permissions
-  dir = opendir("/etc/permissions.d");
+  dir = opendir(directory);
   if (dir)
     {
       char** files = NULL;
@@ -373,7 +352,7 @@ collect_permfiles()
               if (i && !strcmp(files[i-1], files[i]))
                 continue;
 
-              snprintf(fn, sizeof(fn), "/etc/permissions.d/%s", files[i]);
+              snprintf(fn, sizeof(fn), "%s/%s", directory, files[i]);
               if (access(fn, R_OK) == 0)
                 {
                   ensure_array((void**)&permfiles, &npermfiles);
@@ -382,7 +361,7 @@ collect_permfiles()
 
               for (l = 0; l < nlevel; ++l)
                 {
-                  snprintf(fn, sizeof(fn), "/etc/permissions.d/%s.%s", files[i], level[l]);
+                  snprintf(fn, sizeof(fn), "%s/%s.%s", directory, files[i], level[l]);
 
                   if (access(fn, R_OK) == 0)
                     {
@@ -399,6 +378,54 @@ collect_permfiles()
         }
       free(files);
     }
+}
+
+static void
+collect_permfiles()
+{
+  size_t i;
+
+  // 1. central fixed permissions file
+  if (access("/usr/share/permissions/permissions", R_OK) == 0)
+    {
+      ensure_array((void**)&permfiles, &npermfiles);
+      permfiles[npermfiles++] = strdup("/usr/share/permissions/permissions");
+    }
+  else if (access("/etc/permissions", R_OK) == 0)
+    {
+      ensure_array((void**)&permfiles, &npermfiles);
+      permfiles[npermfiles++] = strdup("/etc/permissions");
+    }
+
+  // 2. central easy, secure paranoid as those are defined by SUSE
+  for (i = 0; i < nlevel; ++i)
+    {
+      if (!strcmp(level[i], "easy")
+              || !strcmp(level[i], "secure")
+              || !strcmp(level[i], "paranoid"))
+        {
+          char fn[4096];
+          snprintf(fn, sizeof(fn), "/usr/share/permissions/permissions.%s", level[i]);
+          if (access(fn, R_OK) == 0)
+            {
+              ensure_array((void**)&permfiles, &npermfiles);
+              permfiles[npermfiles++] = strdup(fn);
+            }
+	  else
+	    {
+	      snprintf(fn, sizeof(fn), "/etc/permissions.%s", level[i]);
+	      if (access(fn, R_OK) == 0)
+		{
+		  ensure_array((void**)&permfiles, &npermfiles);
+		  permfiles[npermfiles++] = strdup(fn);
+		}
+	    }
+        }
+    }
+  // 3. package specific permissions
+  read_permissions_d("/usr/share/permissions/permissions.d");
+  read_permissions_d("/etc/permissions.d");
+
   // 4. central permissions files with user defined level incl 'local'
   for (i = 0; i < nlevel; ++i)
     {


### PR DESCRIPTION
/etc/permissions and /etc/permissions.* (except .local) are neither configuration files nor templates, an admin should never modify them.
Move this files to /usr/share/permissions where they belong according to the FHS.