### PR TITLE
chkstat bug fixes

### DIFF
--- a/src/chkstat.c
+++ b/src/chkstat.c
@@ -1223,13 +1223,15 @@ main(int argc, char **argv)
           fprintf(stderr, "%s: chmod: %s\n", e->file+rootl, strerror(errno));
           errors++;
         }
-      if (!caps_ok)
+      // chown and - depending on the file system - chmod clear existing capabilities
+      // so apply the intended caps even if they were correct previously
+      if (e->caps || !caps_ok)
         {
           if (S_ISREG(stb.st_mode))
             {
               // cap_set_file() tries to be helpful and does a lstat() to check that it isn't called on
               // a symlink. So we have to open() it (without O_PATH) and use cap_set_fd().
-              int cap_fd = open(fd_path, O_NOATIME | O_CLOEXEC);
+              int cap_fd = open(fd_path, O_NOATIME | O_CLOEXEC | O_RDONLY);
               if (cap_fd == -1)
                 {
                   fprintf(stderr, "%s: open() for changing capabilities: %s\n", e->file+rootl, strerror(errno));
@@ -1237,8 +1239,12 @@ main(int argc, char **argv)
                 }
               else if (cap_set_fd(cap_fd, e->caps))
                 {
-                  fprintf(stderr, "%s: cap_set_fd: %s\n", e->file+rootl, strerror(errno));
-                  errors++;
+                  // ignore ENODATA when clearing caps - it just means there were no caps to remove
+                  if (errno != ENODATA || e->caps)
+                    {
+                      fprintf(stderr, "%s: cap_set_fd: %s\n", e->file+rootl, strerror(errno));
+                      errors++;
+                    }
                 }
               if (cap_fd != -1)
                 close(cap_fd);


### PR DESCRIPTION
@mgerstner ou're the one most familiar with my recent sec fixes, so you're probably the best one to review.

-----

d8470ce is the fix for Factory. Without access to `/proc`, there the plan is to switch to read-only warning mode and error out with a bad exit code - and lobby users like kiwi to just provide us with a working `/proc`.

On older codestreams, I'd skip the fourth hunk of d8470ce and transparently fall back to insecure path accesses when `/proc` is unavailable. That fixes the breakage of image building tools in these releases, but re-opens the vulnerability under these circumstances. For image building that's fine since there's no untrusted code running in parallel that could interfere. And I can't really think of any other reason why `chkstat` would run without `/proc`, so this *should* be fine.

We could also just mount `/proc` ourselves (and unmount before exit). That's quite horrible, but it's also quite appealing in its way.

-----

0b9cc76 fixes the wrong error message found through #32, and has some readability improvements for `safe_open()`. And it has a drive-by-fix in the symlink handling.