### PR TITLE
Fix symlink handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DESTDIR=
 LDLIBS=-lcap
 prefix=/usr
 sysconfdir=/etc
+permissionsdir=/usr/share/permissions
 bindir=$(prefix)/bin
 fillupdir=/var/adm/fillup-templates
 datadir=$(prefix)/share
@@ -29,15 +30,16 @@ all: src/chkstat
 	@if grep -o -P '\t' src/chkstat.cpp ; then echo "error: chkstat.c mixes tabs and spaces!" ; touch src/chkstat.cpp ; exit 1 ; fi ; :
 
 install: all
-	@for i in $(bindir) $(man8dir) $(man5dir) $(fillupdir) $(sysconfdir) $(zypp_commit_plugins); \
+	@for i in $(bindir) $(man8dir) $(man5dir) $(fillupdir) $(sysconfdir) $(permissionsdir) $(zypp_commit_plugins); \
 		do install -d -m 755 $(DESTDIR)$$i; done
 	@install -m 755 src/chkstat $(DESTDIR)$(bindir)
 	@install -m 644 man/chkstat.8 $(DESTDIR)$(man8dir)
 	@install -m 644 man/permissions.5 $(DESTDIR)$(man5dir)
 	@install -m 644 etc/sysconfig.security $(DESTDIR)$(fillupdir)
 	@install -m 755 zypper-plugin/permissions.py $(DESTDIR)$(zypp_commit_plugins)
-	@for i in etc/permissions* profiles/permissions.*; \
-		do install -m 644 $$i $(DESTDIR)$(sysconfdir); done
+	@for i in etc/permissions profiles/permissions.*; \
+		do install -m 644 $$i $(DESTDIR)$(permissionsdir); done
+	@install -m 644 etc/permissions.local $(DESTDIR)$(sysconfdir)
 
 
 clean:

--- a/etc/permissions
+++ b/etc/permissions
@@ -1,4 +1,4 @@
-# /etc/permissions
+# /usr/share/permissions/permissions
 #
 # Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.
 # Copyright (c) 2011 SUSE Linux Products GmbH Nuernberg, Germany.
@@ -9,10 +9,10 @@
 # to check or set the modes and ownerships of files and directories in the installation.
 #
 # There is a set of files with similar meaning in a SUSE installation:
-# /etc/permissions  (This file)
-# /etc/permissions.easy
-# /etc/permissions.secure
-# /etc/permissions.paranoid
+# /usr/share/permissions/permissions  (This file)
+# /usr/share/permissions/permissions.easy
+# /usr/share/permissions/permissions.secure
+# /usr/share/permissions/permissions.paranoid
 # /etc/permissions.local
 # Please see the respective files for their meaning.
 #
@@ -28,11 +28,11 @@
 # /etc/sysconfig/security to determine which security level to
 # apply.
 # In addition to the central files listed above the directory
-# /etc/permissions.d/ can contain permission files that belong to
-# the packages they modify file modes for. These permission files
-# are to switch between conflicting file modes of the same file
-# paths in different packages (popular example: sendmail and
-# postfix, path /usr/sbin/sendmail).
+# /usr/share/permissions/permissions.d/ can contain permission files
+# that belong to the packages they modify file modes for. These
+# permission files are to switch between conflicting file modes of
+# the same file paths in different packages (popular example:
+# sendmail and postfix, path /usr/sbin/sendmail).
 
 #
 # root directories:

--- a/man/chkstat.8
+++ b/man/chkstat.8
@@ -69,9 +69,10 @@ Check files relative to the specified directory.
 .PP
 .SH EXAMPLES
 .PP
-.B chkstat --set /etc/permissions /etc/permissions.secure
+.B chkstat --set /usr/share/permissions/permissions /usr/share/permissions/permissions.secure
 .PP
-parses the files /etc/permissions and /etc/permissions and sets the
+parses the files /usr/share/permissions/permissions and
+/usr/share/permissions/permissions and sets the
 access mode and the user- and group memberships for each file listed.
 .PP
 .B chkstat --system /bin/ping

--- a/man/permissions.5
+++ b/man/permissions.5
@@ -9,7 +9,7 @@ permission - default permission settings
 The chkstat program sets permissions and ownerships according to the
 permission files\.
 .SH "DESCRIPTION"
-\- The files /etc/permissions\.* are line based and space delimited\.
+\- The files /usr/share/permissions/permissions\.* are line based and space delimited\.
 .br
 \- Lines starting with # are comments\.
 .br
@@ -25,15 +25,15 @@ the information of the previous line with file capabilites.
 .br
 .SH "FILES"
 .sp
-/etc/permissions
+/usr/share/permissions/permissions
 .br
-/etc/permissions\.easy
+/usr/share/permissions/permissions\.easy
 .br
-/etc/permissions\.secure
+/usr/share/permissions/permissions\.secure
 .br
-/etc/permissions\.paranoid
+/usr/share/permissions/permissions\.paranoid
 .br
-/etc/permissions\.d/*
+/usr/share/permissions/permissions\.d/*
 .br
 /etc/permissions\.local
 .br

--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -4,10 +4,11 @@
 # Author: Roman Drahtmueller <draht@suse.de>, 2001
 #
 # 
-# See /etc/permissions for general hints on how to use this file.
+# See /usr/share/permissions/permissions for general hints on how to use this
+# file.
 #
-# /etc/permissions.easy is set up for the use in a standalone and single-user
-# installation to make things "work" out-of-the box.
+# /usr/share/permissions/permissions.easy is set up for the use in a
+# standalone and single-user installation to make things "work" out-of-the box.
 # Some of the settings might be considered somewhat lax from the security
 # standpoint. These aspects are handled differently in the permissions.secure
 # file.

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -1,14 +1,16 @@
-# /etc/permissions.paranoid
+# /usr/share/permissions/permissions.paranoid
 #
 # Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
 #
 # Author: Roman Drahtmueller <draht@suse.de>, 2001
 #
 # 
-# See /etc/permissions for general hints on how to use this file.
+# See /usr/share/permissions/permissions for general hints on how to use
+# this file.
 #
-# /etc/permissions.paranoid is NOT designed to be used in a single-user as
-# well as a multi-user installation, be it networked or not.
+# /usr/share/permissions/permissions.paranoid is NOT designed to be used
+# in a single-user as well as a multi-user installation, be it networked
+# or not.
 #
 # Derived from /etc/permissions.secure, it has _all_ sgid and suid bits
 # cleared - therefore, the system is probably not useable for non-privileged

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -1,16 +1,17 @@
-# /etc/permissions.secure
+# /usr/share/permissions/permissions.secure
 #
 # Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
 #
 # Author: Roman Drahtmueller <draht@suse.de>, 2001
 #
 # 
-# See /etc/permissions for general hints on how to use this file.
+# See /usr/share/permissions/permissions for general hints on how to use
+# this file.
 #
-# /etc/permissions.secure is designed for the use in a multi-user and
-# networked installation. Most privileged file modes are disabled here.
-# Many programs that still have their suid- or sgid-modes have had their
-# security problems in the past already.
+# /usr/share/permissions/permissions.secure is designed for the use in a
+# multi-user and networked installation. Most privileged file modes are
+# disabled here. Many programs that still have their suid- or sgid-modes
+# have had their security problems in the past already.
 # The primary target of this configuration is to make the basic things
 # such as changing passwords, the basic networking programs as well as
 # some of the all-day work programs properly function for the unprivileged

--- a/src/chkstat.cpp
+++ b/src/chkstat.cpp
@@ -633,14 +633,17 @@ safe_open(char *path, struct stat *stb, uid_t target_uid, bool *traversed_insecu
 
         if (S_ISLNK(stb->st_mode))
         {
+            // If the path configured in the permissions configuration is a symlink, we don't follow it.
+            // This is to emulate legacy behaviour: old insecure versions of chkstat did a simple lstat(path) as 'protection' against malicious symlinks.
+            if (is_final_path_element || ++lcnt >= 256)
+                goto fail;
+
             // Don't follow symlinks owned by regular users.
             // In theory, we could also trust symlinks where the owner of the target matches the owner
             // of the link, but we're going the simple route for now.
             if (stb->st_uid && stb->st_uid != euid)
                 goto fail_insecure_path;
 
-            if (++lcnt >= 256)
-                goto fail;
             char linkbuf[PATH_MAX];
             ssize_t l = readlinkat(pathfd, "", linkbuf, sizeof(linkbuf) - 1);
 
@@ -670,29 +673,17 @@ safe_open(char *path, struct stat *stb, uid_t target_uid, bool *traversed_insecu
                     pathfd = dup(parentfd);
             }
 
-            size_t len;
             // need a temporary buffer because path_rest points into pathbuf
             // and snprintf doesn't allow the same buffer as source and
             // destination
             char tmp[sizeof(pathbuf) - 1];
-
-            if (is_final_path_element)
-            {
-                len = (size_t)snprintf(tmp, sizeof(tmp), "%s", linkbuf);
-            }
-            else
-            {
-                len = (size_t)snprintf(tmp, sizeof(tmp), "%s/%s", linkbuf, path_rest + 1);
-            }
-
+            size_t len = (size_t)snprintf(tmp, sizeof(tmp), "%s/%s", linkbuf, path_rest + 1);
             if (len >= sizeof(tmp))
                 goto fail;
 
             // the first byte of path_rest is always set to a slash at the start of the loop, so we offset by one byte
             strcpy(pathbuf + 1, tmp);
             path_rest = pathbuf;
-
-            is_final_path_element = false;
         }
         else if (S_ISDIR(stb->st_mode))
         {

--- a/src/chkstat.cpp
+++ b/src/chkstat.cpp
@@ -21,7 +21,7 @@
 #ifndef _GNU_SOURCE
 #   define _GNU_SOURCE
 #endif
-#include <stdio.h>
+#include <cstdio>
 #include <pwd.h>
 #include <grp.h>
 #include <sys/types.h>
@@ -29,19 +29,20 @@
 #include <sys/vfs.h>
 #include <linux/magic.h>
 #include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <errno.h>
 #include <dirent.h>
 #include <sys/capability.h>
 #include <fcntl.h>
-#include <stdbool.h>
 #include <sys/param.h>
+#include <cassert>
 
 #define BAD_LINE() \
     fprintf(stderr, "bad permissions line %s:%d\n", permfiles[i], lcnt)
 
-struct perm {
+struct perm
+{
     struct perm *next;
     char *file;
     char *owner;
@@ -500,7 +501,8 @@ usage(int x)
     exit(x);
 }
 
-enum proc_mount_state {
+enum proc_mount_state
+{
     PROC_MOUNT_STATE_UNKNOWN,
     PROC_MOUNT_STATE_AVAIL,
     PROC_MOUNT_STATE_UNAVAIL,

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -550,7 +550,7 @@ class ChkstatRegtest:
 		os.umask(0o022)
 		# use a defined standard PATH list, include sbin
 		# to make sure we also find admin tools
-		os.environ["PATH"] =  "/bin:/sbin:/sbin:/usr/sbin"
+		os.environ["PATH"] =  "/bin:/sbin:/usr/bin:/usr/sbin"
 		os.chdir("/")
 
 		# setup a tmp directory just in case

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -160,6 +160,11 @@ class ChkstatRegtest:
 			help = "By default the regtest tries to (re)build the chkstat binary. If this switch is set then whichever binary is currently found will be used."
 		)
 
+		self.m_parser.add_argument(
+			"--skip-proc", action = 'store_true',
+			help = "Run chkstat without a mounted /proc to test these special chkstat code paths that deal with that condition. This is only really useful in old code streams that attempt to mount their own /proc for backwards compatibility."
+		)
+
 		self.m_args = self.m_parser.parse_args()
 
 	def ensureForkedNamespace(self):
@@ -478,7 +483,7 @@ class ChkstatRegtest:
 			except subprocess.CalledProcessError:
 				pass
 
-	def setupFakeRoot(self):
+	def setupFakeRoot(self, skip_proc):
 
 		# simply operate directly in /tmp in a tmpfs, since we're in a
 		# mount namespace we don't leave behind garbage this way, we
@@ -524,9 +529,11 @@ class ChkstatRegtest:
 				pass
 
 		# mount a new proc corresponding to our forked pid namespace
-		new_proc = self.m_fake_root + "/proc"
-		os.mkdir(new_proc)
-		self.mountProc(new_proc)
+		# unless this is disabled, to test chkstat behaviour without /proc
+		if not skip_proc:
+			new_proc = self.m_fake_root + "/proc"
+			os.mkdir(new_proc)
+			self.mountProc(new_proc)
 
 		# also bind-mount the permissions repo e.g. useful for
 		# debugging
@@ -598,8 +605,10 @@ class ChkstatRegtest:
 
 		# this causes a debug version with additional libasan routines
 		# to be built for testing
+		# asan requires /proc so don't use it if we don't mount it
 		make_env = os.environ.copy()
-		make_env["CHKSTAT_TEST"] = "1"
+		if not self.m_args.skip_proc:
+			make_env["CHKSTAT_TEST"] = "1"
 
 		try:
 			subprocess.check_call(
@@ -633,7 +642,7 @@ class ChkstatRegtest:
 
 		self.buildChkstat()
 
-		self.setupFakeRoot()
+		self.setupFakeRoot(self.m_args.skip_proc)
 		self.checkCapsSupport()
 
 		if self.m_args.enter_fakeroot:

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -2019,9 +2019,11 @@ class TestSymlinkBehaviour(TestBase):
 		# behaviour should be the same for both.
 		#
 		# in older chkstat versions symlinks have not been followed,
-		# in newer ones they are followed in a safe manner, but
+		# in newer ones they were followed in a safe manner, but
 		# in-between an inconsistency was present between absolute and
 		# relative symlinks.
+		# Current versions revert to the legacy behaviour of only following
+		# dir symlinks but not links in the final path element.
 		testroot = self.createAndGetTestDir(0o755)
 
 		testfile1 = os.path.join(testroot, "file1")
@@ -2051,9 +2053,9 @@ class TestSymlinkBehaviour(TestBase):
 		self.switchSystemProfile(testprofile)
 		self.applySystemProfile()
 
-		if self.assertMode(testlink1, 0o644) and \
-			self.assertMode(testlink2, 0o644):
-			print("Modes of symlink targets have been adjusted correctly")
+		if self.assertMode(testlink1, 0o600) and \
+			self.assertMode(testlink2, 0o600):
+			print("Modes of symlink targets have been ignored correctly")
 
 class TestSymlinkDirBehaviour(TestBase):
 


### PR DESCRIPTION
Fixes relative symlinks, and reverts to the legacy behaviour that if the final path element is a link, it doesn't get followed.

Also merges #37 and #30.