### PR TITLE
regtest: adjustments for new config locations

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -397,3 +397,6 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         4755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         4755
+
+# Workload Memory Protection (bsc#1161335)
+/usr/lib/sapwmp/sapwmp-capture                           root:sapsys    4750

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -400,3 +400,6 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         0755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         0755
+
+# Workload Memory Protection (bsc#1161335)
+/usr/lib/sapwmp/sapwmp-capture                           root:sapsys    0750

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -436,3 +436,6 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         4755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         4755
+
+# Workload Memory Protection (bsc#1161335)
+/usr/lib/sapwmp/sapwmp-capture                           root:sapsys    4750


### PR DESCRIPTION
With the permissions files moved over to `/usr/share/permissions`, the testsuite needs adjustment. `/usr/share` is too large to copy over, so I changed the logic for it and `/etc` to do bind-mounts for everything except some unwanted files.

This new mount setup affected one test that randomly happened to use `/usr/share/man` - so I changed it over to `/var/spool`. Then that broke, since my machine has a mount at `/var/lib/libvirt/images` that my local user can't access so I changed `umount` to ignore errors. (A non-recursive mount of `/var` in that test fails for reasons I don't quite understand.)