### PR TITLE
roccat-tools: add entries for yet untracked setgid-dir (bsc#1160285)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -397,3 +397,7 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         4755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         4755
+
+# roccat-tools (bsc#1150336)
+# unsafe multi-user scenario that we currently accept since it's a rare use case
+/var/lib/roccat                                          root:roccat       2770

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -400,3 +400,7 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         0755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         0755
+
+# roccat-tools (bsc#1150336)
+# potentially unsafe multi-user scenario
+/var/lib/roccat                                          root:roccat       0770

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -436,3 +436,7 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         4755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         4755
+
+# roccat-tools (bsc#1150336)
+# unsafe multi-user scenario that we currently accept since it's a rare use case
+/var/lib/roccat                                          root:roccat       2770


### PR DESCRIPTION
Preparation of whitelisting for roccat. Please don't merge yet ... roccat-tools first needs to be adjusted (see bsc#1165566, bsc#1150336).

Especially they must invoke set_permissions and verify_permissions in the spec file, optimally also drop the roccat user (unnecessary) and add an advisory in a SUSE specific README regarding the multi user security.