### PR TITLE
whitelist WMP (bsc#1161335) in master

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -397,3 +397,6 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         4755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         4755
+
+# Workload Memory Protection (bsc#1161335)
+/usr/lib/sapwmp/sapwmp-capture                           root:sapsys    4750

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -400,3 +400,6 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         0755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         0755
+
+# Workload Memory Protection (bsc#1161335)
+/usr/lib/sapwmp/sapwmp-capture                           root:sapsys    0750

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -436,3 +436,6 @@
 # mariadb auth_pam_tool (bsc#1160285)
 /usr/lib/mysql/plugin/auth_pam_tool_dir/auth_pam_tool    root:root         4755
 /usr/lib64/mysql/plugin/auth_pam_tool_dir/auth_pam_tool  root:root         4755
+
+# Workload Memory Protection (bsc#1161335)
+/usr/lib/sapwmp/sapwmp-capture                           root:sapsys    4750


### PR DESCRIPTION
I initially submitted this only to SLE-15-SP2 since that's where it was needed urgently. But we don't want to lose this whitelisting in future releases, so I guess we need this in `master` too even if the binary doesn't exist in factory.

(If we had separation of SLE/openSUSE I guess this is the first thing that'd be in the SLE only bucket.)