### PR TITLE
Refactoring of chkstat into a modern C++ Program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 chkstat
+*.o

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ install: all
 		do install -m 644 $$i $(DESTDIR)$(permissionsdir); done
 	@install -m 644 etc/permissions.local $(DESTDIR)$(sysconfdir)
 
+src/chkstat: src/*.h src/*.cpp | /usr/include/tclap
+
+/usr/include/tclap:
+	@echo "error: The tclap command line parsing library is required for building. Try 'zypper in tclap'."; exit 1; :
 
 clean:
 	/bin/rm -f src/chkstat

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ ifdef CHKSTAT_TEST
 # for testing, add sanitizers:
 CXXFLAGS+=-fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=undefined
 endif
+# if debugging is desired then remove optimizations
+ifdef CHKSTAT_DEBUG
+CXXFLAGS+=-O0
+endif
 CXX=g++
 # link statically against libstdc++. since some people are afraid of ABI
 # changes in this area and since permissions is a base package in SUSE this

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,10 @@ man5dir=$(mandir)/man5
 zypp_plugins=$(prefix)/lib/zypp/plugins
 zypp_commit_plugins=$(zypp_plugins)/commit
 
+OBJS = src/chkstat.o src/utility.o
+
 all: src/chkstat
-	@if grep -o -P '\t' src/chkstat.cpp ; then echo "error: chkstat.c mixes tabs and spaces!" ; touch src/chkstat.cpp ; exit 1 ; fi ; :
+	@if grep -n -o -P '\t' src/*.cpp src/*.h; then echo "error: source has mixed tabs and spaces!" ; touch src/chkstat.cpp ; exit 1 ; fi ; :
 
 install: all
 	@for i in $(bindir) $(man8dir) $(man5dir) $(fillupdir) $(sysconfdir) $(permissionsdir) $(zypp_commit_plugins); \
@@ -38,12 +40,19 @@ install: all
 		do install -m 644 $$i $(DESTDIR)$(permissionsdir); done
 	@install -m 644 etc/permissions.local $(DESTDIR)$(sysconfdir)
 
-src/chkstat: src/*.h src/*.cpp | /usr/include/tclap
+%.o: src/%.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+src/chkstat.o: src/*.h
+src/utility.o: src/utility.h
+
+src/chkstat: $(OBJS) | /usr/include/tclap
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDLIBS) src/*.o -osrc/chkstat
 
 /usr/include/tclap:
 	@echo "error: The tclap command line parsing library is required for building. Try 'zypper in tclap'."; exit 1; :
 
 clean:
-	/bin/rm -f src/chkstat
+	/bin/rm -f src/chkstat src/*.o
 
 .PHONY: all clean

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ man5dir=$(mandir)/man5
 zypp_plugins=$(prefix)/lib/zypp/plugins
 zypp_commit_plugins=$(zypp_plugins)/commit
 
-OBJS = src/chkstat.o src/utility.o
+OBJS = src/chkstat.o src/utility.o src/formatting.o
 
 all: src/chkstat
 	@if grep -n -o -P '\t' src/*.cpp src/*.h; then echo "error: source has mixed tabs and spaces!" ; touch src/chkstat.cpp ; exit 1 ; fi ; :

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ man5dir=$(mandir)/man5
 zypp_plugins=$(prefix)/lib/zypp/plugins
 zypp_commit_plugins=$(zypp_plugins)/commit
 
-FSCAPS_DEFAULT_ENABLED = 1
-CPPFLAGS += -DFSCAPS_DEFAULT_ENABLED=$(FSCAPS_DEFAULT_ENABLED)
-
 all: src/chkstat
 	@if grep -o -P '\t' src/chkstat.cpp ; then echo "error: chkstat.c mixes tabs and spaces!" ; touch src/chkstat.cpp ; exit 1 ; fi ; :
 

--- a/src/chkstat.cpp
+++ b/src/chkstat.cpp
@@ -151,20 +151,6 @@ readline(FILE *fp, char *buf, size_t len)
     return 1;
 }
 
-void
-usage(int x)
-{
-    printf("Usage:\n"
-           "a) chkstat [OPTIONS] <permission-files>...\n"
-           "b) chkstat --system [OPTIONS] <files>...\n"
-           "\n"
-           "Options:\n"
-           "  --root DIR            check files relative to DIR\n"
-           "  --config-root DIR     lookup config files relative to DIR\n"
-    );
-    exit(x);
-}
-
 enum proc_mount_state
 {
     PROC_MOUNT_STATE_UNKNOWN,

--- a/src/chkstat.cpp
+++ b/src/chkstat.cpp
@@ -242,7 +242,7 @@ bool Chkstat::parseSysconfig()
             {
                 m_use_fscaps = false;
             }
-            else
+            else if (!value.empty())
             {
                 // NOTE: this was not a warning/error condition in the
                 // original code

--- a/src/chkstat.cpp
+++ b/src/chkstat.cpp
@@ -652,26 +652,37 @@ void Chkstat::printEntryDifferences(const ProfileEntry &entry, const EntryContex
 
     if (ctx.need_fix_caps && entry.hasCaps())
     {
-        std::cout << " \"" << entry.caps.toText() << "\"";
+        std::cout << " \"" << entry.caps.toText() << "\".";
     }
 
-    std::cout << ". (wrong";
+    std::cout << " (";
+    bool need_comma = false;
 
     if (ctx.need_fix_ownership)
     {
-        std::cout << " owner/group " << FileOwnership(ctx.status);
+        std::cout << "wrong owner/group " << FileOwnership(ctx.status);
+        need_comma = true;
     }
 
     if (ctx.need_fix_perms)
     {
-        std::cout << " permissions " << FileModeInt(ctx.status.getModeBits());
+        if (need_comma)
+        {
+            std::cout << ", ";
+        }
+        std::cout << "wrong permissions " << FileModeInt(ctx.status.getModeBits());
+        need_comma = true;
     }
 
     if (ctx.need_fix_caps)
     {
+        if (need_comma)
+        {
+            std::cout << ", ";
+        }
         if (ctx.caps.valid())
         {
-            std::cout << "capabilities \"" << ctx.caps.toText() << "\"";
+            std::cout << "wrong capabilities \"" << ctx.caps.toText() << "\"";
         }
         else
         {

--- a/src/chkstat.cpp
+++ b/src/chkstat.cpp
@@ -846,11 +846,11 @@ void Chkstat::printHeader()
     }
 }
 
-bool Chkstat::getCapabilities(ProfileEntry &entry, EntryContext &ctx, FileCapabilities &out)
+bool Chkstat::getCapabilities(ProfileEntry &entry, EntryContext &ctx)
 {
-    out.setFromFile(ctx.fd_path);
+    ctx.caps.setFromFile(ctx.fd_path);
 
-    if (!out.valid())
+    if (!ctx.caps.valid())
     {
         if (!entry.hasCaps())
             return true;
@@ -915,7 +915,6 @@ int Chkstat::processEntries()
     EntryContext ctx;
     FileDescGuard fd;
     size_t errors = 0;
-    FileCapabilities caps;
     bool traversed_insecure;
 
     if (m_apply_changes.isSet() && !checkHaveProc())
@@ -968,14 +967,14 @@ int Chkstat::processEntries()
             ctx.fd_path = entry.file;
         }
 
-        if (!getCapabilities(entry, ctx, caps))
+        if (!getCapabilities(entry, ctx))
         {
             errors++;
         }
 
         const bool perm_ok = (file_status.getModeBits()) == entry.mode;
         const bool owner_ok = file_status.matchesOwnership(ctx.uid, ctx.gid);
-        const bool caps_ok = entry.caps == caps;
+        const bool caps_ok = entry.caps == ctx.caps;
 
         if (perm_ok && owner_ok && caps_ok)
             // nothing to do
@@ -1015,9 +1014,9 @@ int Chkstat::processEntries()
                 std::cout << ", ";
             }
 
-            if (caps.valid())
+            if (ctx.caps.valid())
             {
-                std::cout << "capabilities \"" << caps.toText() << "\"";
+                std::cout << "capabilities \"" << ctx.caps.toText() << "\"";
             }
             else
             {

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -68,6 +68,8 @@ protected: // functions
         return m_checklist.find(path) != m_checklist.end();
     }
 
+    bool parseSysconfig();
+
 protected: // data
 
     const int m_argc = 0;
@@ -92,13 +94,19 @@ protected: // data
     TCLAP::MultiArg<std::string> m_file_lists;
 
     TCLAP::ValueArg<std::string> m_root_path;
+    //! alternate config root directory relative to which config files are
+    //! looked up
     TCLAP::ValueArg<std::string> m_config_root_path;
 
     //! positional input arguments: either the files to check for --system
     //! mode or the profiles to parse for non-system mode.
     TCLAP::UnlabeledMultiArg<std::string> m_input_args;
 
+    //! optional explicit set of files to check
     std::set<std::string> m_checklist;
+    //! whether to touch file based capabilities. influenced by command line
+    //! and sysconfig configuration file
+    bool m_use_fscaps = true;
 };
 
 #endif // inc. guard

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -25,7 +25,7 @@ struct ProfileEntry
     std::string file;
     std::string owner;
     std::string group;
-    mode_t mode;
+    mode_t mode = 0;
     FileCapabilities caps;
 
     bool hasCaps() const { return caps.valid(); }
@@ -45,9 +45,9 @@ struct ProfileEntry
 struct EntryContext
 {
     //! the resolved user-id corresponding to the active ProfileEntry
-    uid_t uid;
+    uid_t uid = (uid_t)-1;
     //! the resolved group-id corresponding to the active ProfileEntry
-    gid_t gid;
+    gid_t gid = (gid_t)-1;
     //! the path of the current file to check below a potential m_root_path
     std::string subpath;
     //! a path for safely opening the target file (typically in /proc/self/fd/...)
@@ -57,42 +57,17 @@ struct EntryContext
     //! the actual file status info found on the file
     FileStatus status;
     //! indicates whether actual file permissions need to be fixed
-    bool need_fix_perms;
+    bool need_fix_perms = false;
     //! indicates whether actual file capabilities need to be fixed
-    bool need_fix_caps;
+    bool need_fix_caps = false;
     //! indicates whether actual file user:group ownership needs to be fixed
-    bool need_fix_ownership;
+    bool need_fix_ownership = false;
     //! safeOpen() flags this when it detects an insecure ownership
     //! constellation in the file's path.
-    bool traversed_insecure;
+    bool traversed_insecure = false;
     //! an O_PATH file descriptor for the target file which is set in
     //! safeOpen()
     FileDesc fd;
-
-    explicit EntryContext()
-    {
-        reset();
-    }
-
-    void reset()
-    {
-        uid = (uid_t)-1;
-        gid = (gid_t)-1;
-        subpath.clear();
-        fd_path.clear();
-        if (caps.valid())
-        {
-            caps.destroy();
-        }
-        need_fix_perms = false;
-        need_fix_caps = false;
-        need_fix_ownership = false;
-        traversed_insecure = false;
-        if (fd.valid())
-        {
-            fd.close();
-        }
-    }
 
     //! based on the given \c entry sets need_fix_* members as required
     void check(const ProfileEntry &entry)
@@ -252,7 +227,7 @@ protected: // functions
      * \details
      *      \c entry is potentially modified if capabilities can't be applied.
      *      The return value indicates if an operational error occured but it
-     *      doesn't indicate whether a capability valoue could be assigned.
+     *      doesn't indicate whether a capability valou could be assigned.
      *      Check ctx.caps.valid() for this.
      **/
     bool getCapabilities(ProfileEntry &entry, EntryContext &ctx);

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -6,6 +6,7 @@
 
 // C++
 #include <string>
+#include <set>
 
 /**
  * \brief
@@ -56,6 +57,11 @@ protected: // functions
      **/
     bool validateArguments();
 
+    bool isInChecklist(const std::string &path) const
+    {
+        return m_checklist.find(path) != m_checklist.end();
+    }
+
 protected: // data
 
     const int m_argc = 0;
@@ -85,6 +91,8 @@ protected: // data
     //! positional input arguments: either the files to check for --system
     //! mode or the profiles to parse for non-system mode.
     TCLAP::UnlabeledMultiArg<std::string> m_input_args;
+
+    std::set<std::string> m_checklist;
 };
 
 #endif // inc. guard

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -100,8 +100,13 @@ protected: // functions
      **/
     bool processArguments();
 
-    bool isInChecklist(const std::string &path) const
+    bool needToCheck(const std::string &path) const
     {
+        if (m_checklist.empty())
+            // all paths should be checked
+            return true;
+
+        // otherwise only if the path is explicitly listed
         return m_checklist.find(path) != m_checklist.end();
     }
 

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -265,6 +265,13 @@ protected: // functions
      **/
     bool safeOpen(EntryContext &ctx);
 
+    /**
+     * \brief
+     *      Resolves the file system path for the given file descriptor via
+     *      /proc/self/fd
+     **/
+    std::string getPathFromProc(const FileDescGuard &fd) const;
+
 protected: // data
 
     const int m_argc = 0;

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -57,6 +57,12 @@ protected: // functions
      **/
     bool validateArguments();
 
+    /**
+     * \brief
+     *      Process the already validated command line arguments
+     **/
+    bool processArguments();
+
     bool isInChecklist(const std::string &path) const
     {
         return m_checklist.find(path) != m_checklist.end();

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -84,6 +84,7 @@ protected: // functions
     // functions
     void read_permissions_d(const char *);
     void collect_permfiles(const std::string &);
+    int safe_open(char *path, struct stat *stb, uid_t target_uid, bool *traversed_insecure);
 
 protected: // data
 
@@ -128,6 +129,9 @@ protected: // data
 
     //! permission profile names in the order they should be applied
     std::vector<std::string> m_profiles;
+
+    //! the effective user ID we're running as
+    const uid_t m_euid;
 };
 
 #endif // inc. guard

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -300,6 +300,12 @@ protected: // data
     //! a mapping of file paths to ProfileEntry, denotes the entry to apply
     //! for each path
     std::map<std::string, ProfileEntry> m_profile_entries;
+    /**
+     * \brief
+     *   A collection of the basenames of packages that have already been
+     *   processed by collectPackageProfilePaths()
+     **/
+    std::set<std::string> m_package_profiles_seen;
 
     //! the effective user ID we're running as
     const uid_t m_euid;

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -229,6 +229,10 @@ protected: // functions
     //! collected information
     bool isSafeToChange(const ProfileEntry &entry, const EntryContext &ctx) const;
 
+    //! actually perform the necessary changes for the actual file to arrive
+    //! and the configuration given in \c entry.
+    bool applyChanges(const ProfileEntry &entry, const EntryContext &ctx) const;
+
     /**
      * \brief
      *      Gets the currently set capabilities from ctx.fd_path and stores

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -178,7 +178,7 @@ protected: // functions
      * \return
      *      Whether the line could successfully be parsed
      **/
-    bool parseExtraProfileLine(const std::string &line, ProfileEntry *entry);
+    bool parseExtraProfileLine(const std::string &line, ProfileEntry &entry);
 
     /**
      * \brief

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -54,10 +54,23 @@ struct ProfileEntry
 
     ~ProfileEntry()
     {
+        freeCaps();
+    }
+
+    void freeCaps()
+    {
         if (caps)
         {
             cap_free(caps);
         }
+
+        caps = nullptr;
+    }
+
+    void setCaps(cap_t new_caps)
+    {
+        freeCaps();
+        caps = new_caps;
     }
 };
 
@@ -117,6 +130,26 @@ protected: // functions
      *      Collects configured per-package profiles from the given directory
      **/
     void collectPackageProfiles(const std::string &dir);
+
+    /**
+     * \brief
+     *      Parses the given profile file and stores the according entries in
+     *      m_profile_entries
+     **/
+    void parseProfile(const std::string &path);
+
+    /**
+     * \brief
+     *      Parses extra "+capabilities" lines in permission profiles
+     * \param[in] line 
+     *      The input line from a profile file that starts with "+"
+     * \param[inout] entry
+     *      The last ProfileEntry that was previously parsed from the profile
+     *      file. Can be nullptr for corrupt files.
+     * \return
+     *      Whether the line could successfully be parsed
+     **/
+    bool parseExtraProfileLine(const std::string &line, ProfileEntry *entry);
 
     /**
      * \brief

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -59,6 +59,7 @@ struct EntryContext
     bool need_fix_caps;
     //! indicates whether actual file user:group ownership needs to be fixed
     bool need_fix_ownership;
+    bool traversed_insecure;
 
     explicit EntryContext()
     {
@@ -78,6 +79,7 @@ struct EntryContext
         need_fix_perms = false;
         need_fix_caps = false;
         need_fix_ownership = false;
+        traversed_insecure = false;
     }
 
     //! based on the given \c entry sets need_fix_* members as required
@@ -96,6 +98,8 @@ struct EntryContext
     bool needFixPerms() const { return need_fix_perms; }
     bool needFixCaps() const { return need_fix_caps; }
     bool needFixOwnership() const { return need_fix_ownership; }
+
+    bool traversedInsecure() const { return traversed_insecure; }
 };
 
 //! enum to differentiate different /proc availibility situations
@@ -220,6 +224,10 @@ protected: // functions
     //! outputs the difference that will (or should) be performed to arrived
     //! at the ProfileEntry configuration
     void printEntryDifferences(const ProfileEntry &entry, const EntryContext &ctx) const;
+
+    //! performs checks whether it is safe to adjust the actual file given the
+    //! collected information
+    bool isSafeToChange(const ProfileEntry &entry, const EntryContext &ctx) const;
 
     /**
      * \brief

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -7,6 +7,7 @@
 // C++
 #include <string>
 #include <set>
+#include <vector>
 
 /**
  * \brief
@@ -72,6 +73,18 @@ protected: // functions
 
     bool checkFsCapsSupport() const;
 
+    /**
+     * \brief
+     *      Adds the given profile (suffix) to the list of profiles to be
+     *      processed
+     **/
+    void addProfile(const std::string &name);
+
+    // intermediate member functions in the process of refactoring global
+    // functions
+    void read_permissions_d(const char *);
+    void collect_permfiles(const std::string &);
+
 protected: // data
 
     const int m_argc = 0;
@@ -109,6 +122,12 @@ protected: // data
     //! whether to touch file based capabilities. influenced by command line
     //! and sysconfig configuration file
     bool m_use_fscaps = true;
+
+    //! the default, predefined profile names shipped with permissions
+    static constexpr const char * const PREDEFINED_PROFILES[] = {"easy", "secure", "paranoid"};
+
+    //! permission profile names in the order they should be applied
+    std::vector<std::string> m_profiles;
 };
 
 #endif // inc. guard

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -70,6 +70,8 @@ protected: // functions
 
     bool parseSysconfig();
 
+    bool checkFsCapsSupport() const;
+
 protected: // data
 
     const int m_argc = 0;

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -1,0 +1,92 @@
+#ifndef CHKSTAT_H
+#define CHKSTAT_H
+
+// third party
+#include <tclap/CmdLine.h>
+
+// C++
+#include <string>
+
+/**
+ * \brief
+ *     SwitchArg that can be programmatically set
+ * \details
+ *     TCLAP::SwitchArg doesn't offer a public API to programmatically change
+ *     the switch's value. Therefore this specializations provides an
+ *     additional method to make this possible.
+ **/
+class SwitchArgRW :
+    public TCLAP::SwitchArg
+{
+public:
+    SwitchArgRW(
+        const std::string &flag,
+        const std::string &name,
+        const std::string &desc,
+        TCLAP::CmdLineInterface &parser) :
+        TCLAP::SwitchArg(flag, name, desc, parser)
+    {}
+
+    void setValue(bool val)
+    {
+        _value = val;
+        // this is used for isSet(), _value only for getValue(), so
+        // sync both.
+        _alreadySet = val;
+    }
+};
+
+/**
+ * \brief
+ *     Main application class for Chkstat
+ **/
+class Chkstat
+{
+public: // functions
+
+    Chkstat(int argc, const char **argv);
+
+    int run();
+
+protected: // functions
+
+    /**
+     * \brief
+     *     Validates command line arguments on syntactical and logical level
+     **/
+    bool validateArguments();
+
+protected: // data
+
+    const int m_argc = 0;
+    const char **m_argv = nullptr;
+
+    TCLAP::CmdLine m_parser;
+
+    TCLAP::SwitchArg m_system_mode;
+    TCLAP::SwitchArg m_force_fscaps;
+    TCLAP::SwitchArg m_disable_fscaps;
+    SwitchArgRW m_apply_changes;
+    TCLAP::SwitchArg m_only_warn;
+    SwitchArgRW m_no_header;
+
+    // NOTE: previously chkstat allowed multiple specifications of value
+    // switches like --level and --root but actually only used the last
+    // occurence on the command line. In theory this is a backward
+    // compatiblity break, but it's also kind of a bug.
+
+    TCLAP::MultiArg<std::string> m_examine_paths;
+    TCLAP::ValueArg<std::string> m_force_level_list;
+    TCLAP::MultiArg<std::string> m_file_lists;
+
+    TCLAP::ValueArg<std::string> m_root_path;
+    TCLAP::ValueArg<std::string> m_config_root_path;
+
+    //! positional input arguments: either the files to check for --system
+    //! mode or the profiles to parse for non-system mode.
+    TCLAP::UnlabeledMultiArg<std::string> m_input_args;
+};
+
+#endif // inc. guard
+
+// vim: et ts=4 sts=4 sw=4 :

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -34,6 +34,33 @@ struct ProfileEntry
     }
 };
 
+/**
+ * \brief
+ *  scratch data used while processing individual profile entries in
+ *  processEntries()
+ **/
+struct EntryContext
+{
+    //! the resolved user-id corresponding to the active ProfileEntry
+    uid_t uid;
+    //! the resolved group-id corresponding to the active ProfileEntry
+    gid_t gid;
+    //! the path of the current file to check below a potential m_root_path
+    std::string subpath;
+
+    explicit EntryContext()
+    {
+        reset();
+    }
+
+    void reset()
+    {
+        uid = (uid_t)-1;
+        gid = (gid_t)-1;
+        subpath.clear();
+    }
+};
+
 //! enum to differentiate different /proc availibility situations
 enum class ProcMountState
 {
@@ -139,6 +166,13 @@ protected: // functions
      *      algorithm that carries out required file system operations
      **/
     int processEntries();
+
+    /**
+     * \brief
+     *      Resolves the textual user:group in \c entry and stores the result
+     *      in \c ctx
+     **/
+    bool resolveEntryOwnership(const ProfileEntry &entry, EntryContext &ctx);
 
     //! tests whether /proc is available in a caching manner
     bool checkHaveProc() const;

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -49,6 +49,8 @@ struct EntryContext
     std::string subpath;
     //! a path for safely opening the target file (typically in ///proc/self/fd/...)
     std::string fd_path;
+    //! the actual capabilities currently set on the file
+    FileCapabilities caps;
 
     explicit EntryContext()
     {
@@ -61,6 +63,10 @@ struct EntryContext
         gid = (gid_t)-1;
         subpath.clear();
         fd_path.clear();
+        if (caps.valid())
+        {
+            caps.destroy();
+        }
     }
 };
 
@@ -185,14 +191,15 @@ protected: // functions
 
     /**
      * \brief
-     *      Gets the currently set capabilities from ctx.fd_path and stores them in \c out
+     *      Gets the currently set capabilities from ctx.fd_path and stores
+     *      them in \c ctx.caps
      * \details
      *      \c entry is potentially modified if capabilities can't be applied.
      *      The return value indicates if an operational error occured but it
-     *      doesn't indicate whether \c out was assigned a value. If
-     *      capabilities aren't supported then \c out can still be nullptr.
+     *      doesn't indicate whether a capability valoue could be assigned.
+     *      Check ctx.caps.valid() for this.
      **/
-    bool getCapabilities(ProfileEntry &entry, EntryContext &ctx, FileCapabilities &out);
+    bool getCapabilities(ProfileEntry &entry, EntryContext &ctx);
 
     // intermediate member functions in the process of refactoring global
     // functions

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -47,6 +47,8 @@ struct EntryContext
     gid_t gid;
     //! the path of the current file to check below a potential m_root_path
     std::string subpath;
+    //! a path for safely opening the target file (typically in ///proc/self/fd/...)
+    std::string fd_path;
 
     explicit EntryContext()
     {
@@ -58,6 +60,7 @@ struct EntryContext
         uid = (uid_t)-1;
         gid = (gid_t)-1;
         subpath.clear();
+        fd_path.clear();
     }
 };
 
@@ -182,16 +185,14 @@ protected: // functions
 
     /**
      * \brief
-     *      Gets the currently set capabilities from \c path storing them in \c out
+     *      Gets the currently set capabilities from ctx.fd_path and stores them in \c out
      * \details
      *      \c entry is potentially modified if capabilities can't be applied.
      *      The return value indicates if an operational error occured but it
      *      doesn't indicate whether \c out was assigned a value. If
      *      capabilities aren't supported then \c out can still be nullptr.
-     *
-     *      \c label is a descriptive path label for diagnostic messages.
      **/
-    bool getCapabilities(const std::string &path, const std::string &label, ProfileEntry &entry, FileCapabilities &out);
+    bool getCapabilities(ProfileEntry &entry, EntryContext &ctx, FileCapabilities &out);
 
     // intermediate member functions in the process of refactoring global
     // functions

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -5,8 +5,9 @@
 #include <tclap/CmdLine.h>
 
 // C++
-#include <string>
 #include <set>
+#include <string>
+#include <string_view>
 #include <vector>
 
 /**
@@ -80,10 +81,23 @@ protected: // functions
      **/
     void addProfile(const std::string &name);
 
+    /**
+     * \brief
+     *      Collects all configured profiles
+     *  \details
+     *      Collects all profiles configured in m_profiles from /usr and /etc
+     *      system directories and stores their paths in m_profile_paths.
+     **/
+    void collectProfiles();
+
+    /**
+     * \brief
+     *      Collects configured per-package profiles from the given directory
+     **/
+    void collectPackageProfiles(const std::string &dir);
+
     // intermediate member functions in the process of refactoring global
     // functions
-    void read_permissions_d(const char *);
-    void collect_permfiles(const std::string &);
     int safe_open(char *path, struct stat *stb, uid_t target_uid, bool *traversed_insecure);
 
 protected: // data
@@ -129,6 +143,9 @@ protected: // data
 
     //! permission profile names in the order they should be applied
     std::vector<std::string> m_profiles;
+
+    //! permission profile paths in the order they should be applied
+    std::vector<std::string> m_profile_paths;
 
     //! the effective user ID we're running as
     const uid_t m_euid;

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -217,6 +217,10 @@ protected: // functions
     //! prints an introductory text describing the active configuration
     void printHeader();
 
+    //! outputs the difference that will (or should) be performed to arrived
+    //! at the ProfileEntry configuration
+    void printEntryDifferences(const ProfileEntry &entry, const EntryContext &ctx) const;
+
     /**
      * \brief
      *      Gets the currently set capabilities from ctx.fd_path and stores

--- a/src/formatting.cpp
+++ b/src/formatting.cpp
@@ -46,7 +46,7 @@ std::ostream& operator<<(std::ostream &o, const FileOwnership &fo)
 {
     const struct passwd *pwd = ::getpwuid(fo.getUid());
     const struct group *grp = ::getgrgid(fo.getGid());;
-    
+
     if (pwd)
     {
         o << pwd->pw_name;

--- a/src/formatting.cpp
+++ b/src/formatting.cpp
@@ -1,0 +1,73 @@
+// Linux
+#include <grp.h>
+#include <pwd.h>
+
+// local headers
+#include "formatting.h"
+
+// C++
+#include <iomanip>
+#include <ostream>
+
+void FormattedInt::applyBase(std::ostream &o) const
+{
+    switch(m_base)
+    {
+    default:
+        break;
+    case NumberBase::OCT:
+        o << std::oct; return;
+    case NumberBase::DEC:
+        o << std::dec; return;
+    case NumberBase::HEX:
+        o << std::hex; return;
+    }
+}
+
+std::ostream& operator<<(std::ostream &o, const FormattedInt &fi)
+{
+    // NOTE: if a stream has exceptions enabled then this approach can throw
+    // exceptions, because the stream has no rdbuf.
+    //
+    // but std::ostream::flags() does not contain all stream state e.g.
+    // setfill() is not part of it.
+    std::ios orig_state(nullptr);
+    orig_state.copyfmt(o);
+
+    fi.applyBase(o);
+    o << std::setw(fi.getWidth()) << std::setfill(fi.getFill()) << fi.getVal();
+
+    o.copyfmt(orig_state);
+
+    return o;
+}
+
+std::ostream& operator<<(std::ostream &o, const FileOwnership &fo)
+{
+    const struct passwd *pwd = ::getpwuid(fo.getUid());
+    const struct group *grp = ::getgrgid(fo.getGid());;
+    
+    if (pwd)
+    {
+        o << pwd->pw_name;
+    }
+    else
+    {
+        o << fo.getUid();
+    }
+
+    o << ":";
+
+    if (grp)
+    {
+        o << grp->gr_name;
+    }
+    else
+    {
+        o << fo.getGid();
+    }
+
+    return o;
+}
+
+// vim: et ts=4 sts=4 sw=4 :

--- a/src/formatting.h
+++ b/src/formatting.h
@@ -1,0 +1,92 @@
+#ifndef CHKSTAT_FORMATTING_H
+#define CHKSTAT_FORMATTING_H
+
+// local headers
+#include "utility.h"
+
+// C++
+#include <iosfwd>
+
+enum class NumberBase
+{
+    OCT,
+    DEC,
+    HEX
+};
+
+//! just a type for wrapping integers for outputting them easily in a
+//! formatted manner on std::ostream
+class FormattedInt
+{
+public:
+
+    /**
+     * \param[in] val
+     *  The actual integer value to output as octal
+     * \param[in] width
+     *  Minimum field width the number string will be padded to
+     **/
+    explicit FormattedInt(size_t val) :
+        m_val(val)
+    {}
+
+    size_t getVal() const { return m_val; }
+    size_t getWidth() const { return m_width; }
+    char getFill() const { return m_fill; }
+    NumberBase getBase() const { return m_base; }
+
+    FormattedInt& setFill(const char c) { m_fill = c; return *this; }
+    FormattedInt& setWidth(const size_t w) { m_width = w; return *this; }
+    FormattedInt& setBase(const NumberBase &b) { m_base = b; return *this; }
+
+    void applyBase(std::ostream &o) const;
+
+protected:
+
+    size_t m_val = 0;
+    size_t m_width = 0;
+    char m_fill = '0';
+    NumberBase m_base = NumberBase::DEC;
+};
+
+//! helper type to output a file mode as octal nicely formatted onto an ostream
+class FileModeInt :
+    public FormattedInt
+{
+public:
+    explicit FileModeInt(size_t val) :
+        FormattedInt(val)
+    {
+        setBase(NumberBase::OCT);
+        setWidth(4);
+    }
+};
+
+std::ostream& operator<<(std::ostream &o, const FormattedInt &fi);
+
+//! just a helper type for outputting file ownership on a stream
+class FileOwnership
+{
+public:
+    FileOwnership(uid_t uid, gid_t gid) :
+        m_uid(uid), m_gid(gid)
+    {}
+
+    explicit FileOwnership(const FileStatus &fs) :
+        m_uid(fs.st_uid), m_gid(fs.st_gid)
+    {}
+
+    uid_t getUid() const { return m_uid; }
+    gid_t getGid() const { return m_gid; }
+
+protected:
+
+    uid_t m_uid = (uid_t)-1;
+    gid_t m_gid = (gid_t)-1;
+};
+
+std::ostream& operator<<(std::ostream &o, const FileOwnership &fo);
+
+#endif // inc. guard
+
+// vim: et ts=4 sts=4 sw=4 :

--- a/src/formatting.h
+++ b/src/formatting.h
@@ -49,7 +49,7 @@ protected:
     NumberBase m_base = NumberBase::DEC;
 };
 
-//! helper type to output a file mode as octal nicely formatted onto an ostream
+//! helper type to output a file mode in octal nicely formatted onto an ostream
 class FileModeInt :
     public FormattedInt
 {
@@ -64,7 +64,7 @@ public:
 
 std::ostream& operator<<(std::ostream &o, const FormattedInt &fi);
 
-//! just a helper type for outputting file ownership on a stream
+//! helper type for outputting file ownership on a stream
 class FileOwnership
 {
 public:

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -126,9 +126,9 @@ void FileCapabilities::setFromFile(const std::string &path)
     m_caps = cap_get_file(path.c_str());
 }
 
-bool FileCapabilities::applyToFD(int fd)
+bool FileCapabilities::applyToFD(int fd) const
 {
-    if (cap_set_fd(fd, this->raw()) != 0)
+    if (cap_set_fd(fd, m_caps) != 0)
     {
         return false;
     }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -7,6 +7,10 @@
 // local headers
 #include "utility.h"
 
+// C++
+#include <sstream>
+#include <string>
+
 bool existsFile(const std::string &path)
 {
     int fd = open(path.c_str(), O_RDONLY);
@@ -18,6 +22,26 @@ bool existsFile(const std::string &path)
     }
 
     return false;
+}
+
+void splitWords(const std::string &input, std::vector<std::string> &words)
+{
+    std::stringstream ss;
+    std::string word;
+
+    words.clear();
+    ss.str(input);
+
+    // read whitespace separated words
+    while (!ss.fail())
+    {
+        ss >> word;
+
+        if (!ss.fail())
+        {
+            words.emplace_back(word);
+        }
+    }
 }
 
 // vim: et ts=4 sts=4 sw=4 :

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -56,7 +56,7 @@ void FileDesc::close()
     {
         std::cerr << "Closing FD " << m_fd << ": " << strerror(errno) << std::endl;
     }
-    
+
     invalidate();
 }
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,0 +1,23 @@
+// Linux
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// local headers
+#include "utility.h"
+
+bool existsFile(const std::string &path)
+{
+    int fd = open(path.c_str(), O_RDONLY);
+
+    if (fd != -1)
+    {
+        close(fd);
+        return true;
+    }
+
+    return false;
+}
+
+// vim: et ts=4 sts=4 sw=4 :

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -16,15 +16,7 @@
 
 bool existsFile(const std::string &path)
 {
-    int fd = open(path.c_str(), O_RDONLY);
-
-    if (fd != -1)
-    {
-        close(fd);
-        return true;
-    }
-
-    return false;
+    return access(path.c_str(), R_OK) == 0;
 }
 
 void splitWords(const std::string &input, std::vector<std::string> &words)

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -47,7 +47,7 @@ void splitWords(const std::string &input, std::vector<std::string> &words)
     }
 }
 
-void FileDescGuard::close()
+void FileDesc::close()
 {
     if (!valid())
         return;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -60,4 +60,80 @@ void FileDescGuard::close()
     invalidate();
 }
 
+FileCapabilities::~FileCapabilities()
+{
+    if (valid())
+    {
+        destroy();
+    }
+}
+
+bool FileCapabilities::operator==(const FileCapabilities &other) const
+{
+    if (!valid() && !other.valid())
+        // if both are invalid compare to true
+        return true;
+
+    if (valid() != other.valid())
+        // if only one is invalid then compare to false
+        return false;
+
+    return cap_compare(m_caps, other.m_caps) == 0;
+}
+
+void FileCapabilities::destroy()
+{
+    if (!valid())
+        return;
+
+
+    if (cap_free(m_caps) != 0)
+    {
+        std::cerr << "Freeing file capabilities: " << strerror(errno) << std::endl;
+    }
+
+    invalidate();
+}
+
+void FileCapabilities::setFromText(const std::string &text)
+{
+    destroy();
+
+    m_caps = cap_from_text(text.c_str());
+}
+
+std::string FileCapabilities::toText() const
+{
+    if (!valid())
+        return "";
+
+    auto text = cap_to_text(m_caps, nullptr);
+
+    if (!text)
+        return "";
+
+    auto ret = std::string(text);
+
+    cap_free(text);
+
+    return ret;
+}
+
+void FileCapabilities::setFromFile(const std::string &path)
+{
+    destroy();
+
+    m_caps = cap_get_file(path.c_str());
+}
+
+bool FileCapabilities::applyToFD(int fd)
+{
+    if (cap_set_fd(fd, this->raw()) != 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
 // vim: et ts=4 sts=4 sw=4 :

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,5 +1,7 @@
 // Linux
+#include <errno.h>
 #include <fcntl.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -8,6 +10,7 @@
 #include "utility.h"
 
 // C++
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -42,6 +45,19 @@ void splitWords(const std::string &input, std::vector<std::string> &words)
             words.emplace_back(word);
         }
     }
+}
+
+void FileDescGuard::close()
+{
+    if (!valid())
+        return;
+
+    if (::close(m_fd) != 0)
+    {
+        std::cerr << "Closing FD " << m_fd << ": " << strerror(errno) << std::endl;
+    }
+    
+    invalidate();
 }
 
 // vim: et ts=4 sts=4 sw=4 :

--- a/src/utility.h
+++ b/src/utility.h
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <string>
 #include <string_view>
+#include <vector>
 
 // isspace has overloads which gives trouble with template argument deduction,
 // therefore provide a wrapper
@@ -86,6 +87,10 @@ void appendContainer(T1 &container, const T2 &sequence)
 {
     container.insert(container.end(), sequence.begin(), sequence.end());
 }
+
+//! splits up the \c input string into whitespace separated words and stores
+//! them in \c words
+void splitWords(const std::string &input, std::vector<std::string> &words);
 
 #endif // inc. guard
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -55,6 +55,19 @@ inline bool hasPrefix(const std::string &s, const std::string prefix)
     return s.substr(0, prefix.length()) == prefix;
 }
 
+//! returns whether the given iterable sequence contains the given element \c val
+template <typename T, typename SEQ>
+bool matchesAny(const T &val, const SEQ &seq)
+{
+    for (const auto &e: seq)
+    {
+        if (val == e)
+            return true;
+    }
+
+    return false;
+}
+
 #endif // inc. guard
 
 // vim: et ts=4 sts=4 sw=4 :

--- a/src/utility.h
+++ b/src/utility.h
@@ -128,6 +128,19 @@ void appendContainer(T1 &container, const T2 &sequence)
 //! them in \c words
 void splitWords(const std::string &input, std::vector<std::string> &words);
 
+template <typename T>
+bool stringToUnsigned(const std::string &s, T &out, const size_t base = 10)
+{
+    char *end = nullptr;
+    out = static_cast<T>(std::strtoul(s.c_str(), &end, base));
+    if (end && *end != '\0')
+    {
+        return false;
+    }
+
+    return true;
+}
+
 //! a helper class that wraps a plain POSIX file descriptor and makes sure it
 //! gets closed at descruction/assignment time
 class FileDescGuard

--- a/src/utility.h
+++ b/src/utility.h
@@ -220,6 +220,10 @@ public:
     FileCapabilities& operator=(const FileCapabilities &other) = delete;
 
     bool operator==(const FileCapabilities &other) const;
+    bool operator!=(const FileCapabilities &other) const
+    {
+        return !(*this == other);
+    }
 
     bool valid() const { return m_caps != nullptr; }
     void invalidate() { m_caps = nullptr; }

--- a/src/utility.h
+++ b/src/utility.h
@@ -1,0 +1,60 @@
+#ifndef CHKSTAT_UTILITY_H
+#define CHKSTAT_UTILITY_H
+
+// C++
+#include <cctype>
+#include <string>
+
+// isspace has overloads which gives trouble with template argument deduction,
+// therefore provide a wrapper
+inline bool chkspace(char c) { return std::isspace(c); }
+
+//! remove leading characters characters from the given string, by default
+//! whitespace characters
+template <typename UNARY = bool(char)>
+inline std::string& lstrip(std::string &s, UNARY f = chkspace)
+{
+    auto nonmatch_it = s.end();
+
+    for( auto it = s.begin(); it != s.end(); it++ )
+    {
+        if( !f(*it) )
+        {
+            nonmatch_it = it;
+            break;
+        }
+    }
+
+    s = s.substr(static_cast<size_t>(nonmatch_it - s.begin()));
+
+    return s;
+}
+
+//! remove trailing characters from the given string, by default
+//! whitespace characters
+template <typename UNARY = bool(char)>
+inline std::string& rstrip(std::string &s, UNARY f = chkspace)
+{
+    while( !s.empty() && f(*s.rbegin()) )
+        s.pop_back();
+    return s;
+}
+
+//! remove leading and trailing characters from the given string, by
+//! default whitespace characters
+template <typename UNARY = bool(char)>
+std::string& strip(std::string &s, UNARY f = chkspace)
+{
+    lstrip(s, f);
+    return rstrip(s, f);
+}
+
+//! checks whether the given string has the given prefix
+inline bool hasPrefix(const std::string &s, const std::string prefix)
+{
+    return s.substr(0, prefix.length()) == prefix;
+}
+
+#endif // inc. guard
+
+// vim: et ts=4 sts=4 sw=4 :

--- a/src/utility.h
+++ b/src/utility.h
@@ -4,6 +4,7 @@
 // C++
 #include <cctype>
 #include <string>
+#include <string_view>
 
 // isspace has overloads which gives trouble with template argument deduction,
 // therefore provide a wrapper
@@ -50,9 +51,18 @@ std::string& strip(std::string &s, UNARY f = chkspace)
 }
 
 //! checks whether the given string has the given prefix
-inline bool hasPrefix(const std::string &s, const std::string prefix)
+inline bool hasPrefix(const std::string &s, const std::string &prefix)
 {
     return s.substr(0, prefix.length()) == prefix;
+}
+
+//! checks whether the given string has the given suffix
+inline bool hasSuffix(const std::string_view &s, const std::string &suffix)
+{
+    if (suffix.length() > s.length())
+        return false;
+
+    return s.substr(s.length() - suffix.length()) == suffix;
 }
 
 //! returns whether the given iterable sequence contains the given element \c val
@@ -66,6 +76,15 @@ bool matchesAny(const T &val, const SEQ &seq)
     }
 
     return false;
+}
+
+//! performs a file existence test for the given path
+bool existsFile(const std::string &path);
+
+template <typename T1, typename T2>
+void appendContainer(T1 &container, const T2 &sequence)
+{
+    container.insert(container.end(), sequence.begin(), sequence.end());
 }
 
 #endif // inc. guard

--- a/src/utility.h
+++ b/src/utility.h
@@ -253,7 +253,7 @@ public:
      *  Applies the currently stored capability data to the given file
      *  descriptors
      **/
-    bool applyToFD(int fd);
+    bool applyToFD(int fd) const;
 
     /**
      * \brief

--- a/src/utility.h
+++ b/src/utility.h
@@ -10,6 +10,7 @@
 
 // C++
 #include <cctype>
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -169,7 +170,7 @@ public:
         }
     }
 
-    int get() { return m_fd; }
+    int get() const { return m_fd; }
 
     void set(int fd)
     {
@@ -181,7 +182,14 @@ public:
         m_fd = fd;
     }
 
+    void steal(FileDescGuard &other)
+    {
+        set(other.get());
+        other.invalidate();
+    }
+
     bool valid() const { return m_fd != -1; }
+    bool invalid() const { return !valid(); }
     void invalidate() { m_fd = -1; }
 
     void close();
@@ -220,6 +228,16 @@ public:
     bool isWorldWritable() const
     {
         return (this->st_mode & S_IWOTH) != 0;
+    }
+
+    void copy(const struct stat &other)
+    {
+        std::memcpy(this, &other, sizeof(*this));
+    }
+
+    bool fstat(int fd)
+    {
+        return ::fstat(fd, this) == 0;
     }
 
 protected:

--- a/src/utility.h
+++ b/src/utility.h
@@ -197,6 +197,18 @@ public:
         return this->st_uid == uid && this->st_gid == gid;
     }
 
+    //! returns whether this file status and the other file status refer to
+    //! the same file object (based on device and inode identification)
+    bool sameObject(const struct ::stat &other) const
+    {
+        return this->st_dev == other.st_dev && this->st_ino == other.st_ino;
+    }
+
+    bool isWorldWritable() const
+    {
+        return (this->st_mode & S_IWOTH) != 0;
+    }
+
 protected:
 };
 

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -2139,11 +2139,22 @@ class TestSymlinkBehaviour(TestBase):
 
 		testlink1 = os.path.join(testroot, "link1")
 		testlink2 = os.path.join(testroot, "link2")
+		testlink3 = os.path.join(testroot, "link3")
 
 		# absolute symlink
 		os.symlink( testfile1, testlink1 )
 		# relative symlink
 		os.symlink( ".." + testfile2, testlink2 )
+		# a very short relative symlink, middle component of testfile3
+		# this can catch certain classes of processing errors in
+		# safeOpen()
+		os.symlink( "d", testlink3 )
+		# the directory testlink3 is pointing to
+		self.createTestDir(os.path.join(testroot, "d"), 0o755)
+
+
+		testfile3 = os.path.join(testlink3, "file3")
+		self.createTestFile(testfile3, 0o644)
 
 		testprofile = "easy"
 
@@ -2151,6 +2162,7 @@ class TestSymlinkBehaviour(TestBase):
 			testprofile: (
 				self.buildProfileLine(testlink1, 0o644),
 				self.buildProfileLine(testlink2, 0o644),
+				self.buildProfileLine(testfile3, 0o600),
 			)
 		}
 
@@ -2161,6 +2173,9 @@ class TestSymlinkBehaviour(TestBase):
 		if self.assertMode(testlink1, 0o600) and \
 			self.assertMode(testlink2, 0o600):
 			print("Modes of symlink targets have been ignored correctly")
+
+		if self.assertMode(testfile3, 0o600):
+			print("Mode of regular file target with short symlink component was set correctly")
 
 class TestSymlinkDirBehaviour(TestBase):
 

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -958,7 +958,7 @@ class TestBase:
 		color_printer.reset()
 		self.m_warnings += 1
 
-	def complainOnNoSubIdSupport(self):
+	def complainOnMissingSubIdSupport(self):
 		if self.m_main_test_instance.haveSubIdSupport():
 			return False
 
@@ -1190,7 +1190,7 @@ class TestCorrectOwner(TestBase):
 
 	def run(self):
 
-		if self.complainOnNoSubIdSupport():
+		if self.complainOnMissingSubIdSupport():
 			# we need sub-uids to test ownership changes
 			return
 
@@ -1203,22 +1203,24 @@ class TestCorrectOwner(TestBase):
 
 		# we need a defined order of execution here, therefore
 		# iterate over the sorted dictionary keys.
+		# (in newer Python versions 3.6/3.7 dictionaries are sorted by
+		# insertion order by default. Still stay backward compatible
+		# for the moment.)
 		#
 		# we start out from 0:0 and downgrade first to 0:1 then to 1:1
 		# to avoid triggering the "refusing to correct" logic in
 		# chkstat.
 		owners = {
-			"easy": ("0", "0"),
-			"paranoid": ("0", "1"),
-			"secure": ("1", "1"),
+			"easy": (0, 0),
+			"paranoid": (0, 1),
+			"secure": (1, 1),
 		}
 
 		entries = {}
 
 		for profile in sorted(owners.keys()):
 			user, group = owners[profile]
-			lines = entries.setdefault(profile, [])
-			lines.append( self.buildProfileLine(testdir, 0o775, owner = user, group = group) )
+			entries[profile] = [ self.buildProfileLine(testdir, 0o775, owner = user, group = group) ]
 
 		self.addProfileEntries(entries)
 
@@ -1952,7 +1954,7 @@ class TestRejectUserSymlink(TestBase):
 
 	def run(self):
 
-		if self.complainOnNoSubIdSupport():
+		if self.complainOnMissingSubIdSupport():
 			return
 
 		testroot = self.createAndGetTestDir(0o755)

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -141,6 +141,11 @@ class ChkstatRegtest:
 		)
 
 		self.m_parser.add_argument(
+			"--after-test-enter-shell", action = 'store_true',
+			help = "Enter the fake root after the test(s) finished executing."
+		)
+
+		self.m_parser.add_argument(
 			"--list-tests", action = 'store_true',
 			help = "Just list the available tests"
 		)
@@ -693,6 +698,10 @@ class ChkstatRegtest:
 		if self.m_args.test and tests_run == 0:
 			print("No such test", self.m_args.test)
 			tests_failed += 1
+
+		if self.m_args.after_test_enter_shell:
+			print("Entering shell after test execution")
+			self.enterShell()
 
 		print("\n")
 		print(str(tests_run).rjust(2), "tests run")

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -161,6 +161,11 @@ class ChkstatRegtest:
 		)
 
 		self.m_parser.add_argument(
+			"--build-debug", action = 'store_true',
+			help = "Build a more debug friendly version of chkstat to make tracking down bugs in `gdb` easier"
+		)
+
+		self.m_parser.add_argument(
 			"--skip-make", action = 'store_true',
 			help = "By default the regtest tries to (re)build the chkstat binary. If this switch is set then whichever binary is currently found will be used."
 		)
@@ -610,6 +615,8 @@ class ChkstatRegtest:
 		make_env = os.environ.copy()
 		if not self.m_args.skip_proc:
 			make_env["CHKSTAT_TEST"] = "1"
+		if self.m_args.build_debug:
+			make_env["CHKSTAT_DEBUG"] = "1"
 
 		try:
 			subprocess.check_call(


### PR DESCRIPTION
This finalizes my hackweek project to "rewrite chkstat". Based on the regression test suite I was now able to refactor the code base step by step to arrive at a new code base that is, I think, more digestible than what we had before.

I tried hard not to change program behaviour but in some spots it still happened:

- ealier long command line options could be specified using only a single `--` or a  double `-`. Now only `--` is supported any more. I'm not aware of any users (in code) of the single `-` variant.
- earlier duplicate specifications of the same command line option was tolerated, overwriting previous values found on the command line. Now only a single specification is allowed any more.
- earlier the "header" was only printed when an actual mismatch was found. Now the header is unconditionally printed expected when `--noheader` is passed.
- the diagnostic output changed a bit in format but I hope there aren't any programs out there that parse the chkstat output (except the regtest suite).