### PR TITLE
Make sure linker flags are the last arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ src/chkstat.o: src/*.h
 src/utility.o: src/utility.h
 
 src/chkstat: $(OBJS) | /usr/include/tclap
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDLIBS) src/*.o -osrc/chkstat
+	$(CXX) $(CXXFLAGS) src/*.o -o src/chkstat $(LDFLAGS) $(LDLIBS)
 
 /usr/include/tclap:
 	@echo "error: The tclap command line parsing library is required for building. Try 'zypper in tclap'."; exit 1; :


### PR DESCRIPTION
This fixes a compilation error I see on Tumbleweed:

> [    2s] g++ -g -O2 -std=c++17 -Werror -Wall -Wextra -pedantic -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wdouble-promotion  -Wshadow  -Wformat=2 -Wsign-conversion -static-libstdc++
 -lcap src/*.o -osrc/chkstat                                                                                                                                                                                       
[    2s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: src/utility.o: in function `FileCapabilities::operator==(FileCapabilities const&) const':                                        
[    2s] /home/abuild/rpmbuild/BUILD/permissions-20200512/src/utility.cpp:73: undefined reference to `cap_compare'                                                                                                 
[    2s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: src/utility.o: in function `FileCapabilities::destroy()':                                                                        
[    2s] /home/abuild/rpmbuild/BUILD/permissions-20200512/src/utility.cpp:82: undefined reference to `cap_free'                                                                                                    
[    2s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: src/utility.o: in function `FileCapabilities::setFromText(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&)':                                                                                                                                                                                                 
[    2s] /home/abuild/rpmbuild/BUILD/permissions-20200512/src/utility.cpp:94: undefined reference to `cap_from_text'                                                                                               
[    2s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: src/utility.o: in function `FileCapabilities::setFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&)':                                                                                                                                                                                                 
[    2s] /home/abuild/rpmbuild/BUILD/permissions-20200512/src/utility.cpp:118: undefined reference to `cap_get_file'                                                                                               
[    2s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: src/utility.o: in function `FileCapabilities::applyToFD(int) const':                                                             
[    2s] /home/abuild/rpmbuild/BUILD/permissions-20200512/src/utility.cpp:123: undefined reference to `cap_set_fd'                                                                                                 
[    2s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: src/utility.o: in function `FileCapabilities::toText[abi:cxx11]() const':                                                        
[    2s] /home/abuild/rpmbuild/BUILD/permissions-20200512/src/utility.cpp:102: undefined reference to `cap_to_text'                                                                                                
[    2s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/permissions-20200512/src/utility.cpp:109: undefined reference to `cap_free'