### PR TITLE
fixed permissions: adjust to new libexec dir location (bsc#1171164)

### DIFF
--- a/etc/permissions
+++ b/etc/permissions
@@ -120,7 +120,7 @@
 /etc/sysconfig/network/providers/                       root:root          700
 
 # utempter
-/usr/lib/utempter/utempter                              root:utmp         2755
+/usr/libexec/utempter/utempter                          root:utmp         2755
 
 # ensure correct permissions on ssh files to avoid sshd refusing
 # logins (bnc#398250)


### PR DESCRIPTION
This is an addition to commit 8c6029212030ca9c4fc90a60ff26411acd64a565,
which missed the fixed permissions settings. The only affected package
utempter is already using the new path so there should be no reason to
keep the old one around.