### PR TITLE
whitelist texlive public binary (bsc#1171686)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -447,3 +447,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+
+# binary that launches texlive tools with group "mktex" (bsc#1171686)
+/usr/lib/mktex/public                                   root:mktex 2755
+/usr/libexec/mktex/public                               root:mktex 2755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -447,3 +447,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  0750
+
+# binary that launches texlive tools with group "mktex" (bsc#1171686)
+/usr/lib/mktex/public                                   root:mktex 0755
+/usr/libexec/mktex/public                               root:mktex 0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -484,3 +484,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+
+# binary that launches texlive tools with group "mktex" (bsc#1171686)
+/usr/lib/mktex/public                                   root:mktex 2755
+/usr/libexec/mktex/public                               root:mktex 2755


### PR DESCRIPTION
texlive has long shipped `/usr/lib/mktex/public`. It got away without being whitelisted here by packaging it `0755` in the RPM but with `%set_permissions` that ended up setting the setgid bit through the whitelisted `/etc/permissions.d/texlive`.

@jsegitz please review since you're most familiar with the texlive packaging.