### PR TITLE
permissions fixed profile: utempter: reinstate libexec compatibility …

### DIFF
--- a/etc/permissions
+++ b/etc/permissions
@@ -120,6 +120,7 @@
 /etc/sysconfig/network/providers/                       root:root          700
 
 # utempter
+/usr/lib/utempter/utempter                              root:utmp         2755
 /usr/libexec/utempter/utempter                          root:utmp         2755
 
 # ensure correct permissions on ssh files to avoid sshd refusing


### PR DESCRIPTION
…entry

In PR #69 the assumption was that %{_libexecdir} was already migrated to
the new path. But this is not the case. Therefore we need to keep the
compatibility entry also for utempter at the moment.