### PR TITLE
permission profiles: reinstate kdesud for kde5

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -133,6 +133,10 @@
 # framebuffer terminal emulator (japanese)
 /usr/bin/jfbterm                                        root:tty          6755
 
+# kdesud (bsc#872276)
+/usr/lib/libexec/kf5/kdesud                             root:nogroup      2755
+/usr/lib64/libexec/kf5/kdesud                           root:nogroup      2755
+
 #
 # amanda
 #

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -146,6 +146,10 @@
 # framebuffer terminal emulator (japanese).
 /usr/bin/jfbterm                                        root:tty          0755
 
+# kdesud (bsc#872276)
+/usr/lib/libexec/kf5/kdesud                             root:nogroup      0755
+/usr/lib64/libexec/kf5/kdesud                           root:nogroup      0755
+
 #
 # amanda
 #

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -173,6 +173,10 @@
 # framebuffer terminal emulator (japanese)
 /usr/bin/jfbterm                                        root:tty          0755
 
+# kdesud (bsc#872276)
+/usr/lib/libexec/kf5/kdesud                             root:nogroup      2755
+/usr/lib64/libexec/kf5/kdesud                           root:nogroup      2755
+
 #
 # amanda
 #


### PR DESCRIPTION
The cleanup commit e2876f93279d472b816cc720f59317ba38b92241 overlooked
that a still valid kde5 entry was among those kde4 entries. This commit
reintroduces the now missing entries.