### PR TITLE
pcp: remove no longer needed / conflicting entries

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -289,13 +289,6 @@
 /usr/lib/uucp/uucico                                    uucp:uucp         6555
 /usr/lib/uucp/uuxqt                                     uucp:uucp         6555
 
-# pcp (bnc#782967)
-/var/lib/pcp/tmp/					root:root	  1777
-/var/lib/pcp/tmp/pmdabash/				root:root	  1777
-/var/lib/pcp/tmp/mmv/					root:root	  1777
-/var/lib/pcp/tmp/pmlogger/				root:root	  1777
-/var/lib/pcp/tmp/pmie/					root:root	  1777
-
 # PolicyKit (#295341)
 /usr/lib/PolicyKit/polkit-set-default-helper            polkituser:root   4755
 /usr/lib/PolicyKit/polkit-read-auth-helper              root:polkituser   2755

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -299,13 +299,6 @@
 /usr/lib/uucp/uucico                                    uucp:uucp         0555
 /usr/lib/uucp/uuxqt                                     uucp:uucp         0555
 
-# pcp (bnc#782967)
-/var/lib/pcp/tmp/					root:root	  0755
-/var/lib/pcp/tmp/pmdabash/				root:root	  0755
-/var/lib/pcp/tmp/mmv/					root:root	  0755
-/var/lib/pcp/tmp/pmlogger/				root:root	  0755
-/var/lib/pcp/tmp/pmie/					root:root	  0755
-
 # PolicyKit (#295341)
 /usr/lib/PolicyKit/polkit-set-default-helper            root:polkituser   0755
 /usr/lib/PolicyKit/polkit-read-auth-helper              root:polkituser   0755

--- a/permissions.secure
+++ b/permissions.secure
@@ -329,13 +329,6 @@
 /usr/lib/uucp/uuxqt                                     uucp:uucp         6555
 
 
-# pcp (bnc#782967)
-/var/lib/pcp/tmp/					root:root	  0755
-/var/lib/pcp/tmp/pmdabash/				root:root	  0755
-/var/lib/pcp/tmp/mmv/					root:root	  0755
-/var/lib/pcp/tmp/pmlogger/				root:root	  0755
-/var/lib/pcp/tmp/pmie/					root:root	  0755
-
 # PolicyKit (#295341)
 /usr/lib/PolicyKit/polkit-set-default-helper            polkituser:root   4755
 /usr/lib/PolicyKit/polkit-read-auth-helper              root:polkituser   2755


### PR DESCRIPTION
In Feb 2015 via OBS sr#288085, pcp no longer invokes the
%set_permissions macros, because the directories are now owned by
unprivileged users.