### PR TITLE
dbus-1: adjust to new libexec dir location (bsc#1171164)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -199,8 +199,9 @@
 /usr/libexec/polkit-1/polkit-agent-helper-1             root:root         4755
 /usr/bin/pkexec                                         root:root         4755
 
-# dbus-1 (#333361, #1056764)
+# dbus-1 (#333361, #1056764, bsc#1171164)
 /usr/lib/dbus-1/dbus-daemon-launch-helper               root:messagebus   4750
+/usr/libexec/dbus-1/dbus-daemon-launch-helper           root:messagebus   4750
 
 # policycoreutils (#440596)
 /usr/bin/newrole                                        root:root         4755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -212,8 +212,9 @@
 /usr/libexec/polkit-1/polkit-agent-helper-1             root:root         0755
 /usr/bin/pkexec                                         root:root         0755
 
-# dbus-1 (#333361, #1056764)
+# dbus-1 (#333361, #1056764, bsc#1171164)
 /usr/lib/dbus-1/dbus-daemon-launch-helper               root:messagebus   0750
+/usr/libexec/dbus-1/dbus-daemon-launch-helper           root:messagebus   0750
 
 # policycoreutils (#440596)
 /usr/bin/newrole                                        root:root         0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -240,8 +240,9 @@
 /usr/libexec/polkit-1/polkit-agent-helper-1             root:root         4755
 /usr/bin/pkexec                                         root:root         4755
 
-# dbus-1 (#333361 #1056764)
+# dbus-1 (#333361 #1056764, bsc#1171164)
 /usr/lib/dbus-1/dbus-daemon-launch-helper               root:messagebus   4750
+/usr/libexec/dbus-1/dbus-daemon-launch-helper           root:messagebus   4750
 
 # policycoreutils (#440596)
 /usr/bin/newrole                                        root:root         0755


### PR DESCRIPTION
Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1171164