### PR TITLE
etc/permissions: fix mtr permission

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -99,7 +99,7 @@
 /usr/bin/ping                                           root:root         0755
  +capabilities cap_net_raw=p
 # mtr is linked against ncurses. For dialout only.
-/usr/sbin/mtr                                           root:dialout      0750
+/usr/sbin/mtr-packet                                    root:dialout      0750
  +capabilities cap_net_raw=ep
 
 # exim

--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -98,8 +98,8 @@
  +capabilities cap_net_raw=p
 /usr/bin/ping                                           root:root         0755
  +capabilities cap_net_raw=p
-# mtr is linked against ncurses. For dialout only.
-/usr/sbin/mtr-packet                                    root:dialout      0750
+# mtr
+/usr/sbin/mtr-packet                                    root:root         0755
  +capabilities cap_net_raw=ep
 
 # exim

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -113,8 +113,8 @@
 #
 /usr/bin/clockdiff                                      root:root         0755
 /usr/bin/ping                                           root:root         0755
-# mtr is linked against ncurses.
-/usr/sbin/mtr-packet                                    root:dialout      0750
+# mtr
+/usr/sbin/mtr-packet                                    root:root         0755
 
 # exim
 /usr/sbin/exim                                          root:root         0755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -114,7 +114,7 @@
 /usr/bin/clockdiff                                      root:root         0755
 /usr/bin/ping                                           root:root         0755
 # mtr is linked against ncurses.
-/usr/sbin/mtr                                           root:dialout      0750
+/usr/sbin/mtr-packet                                    root:dialout      0750
 
 # exim
 /usr/sbin/exim                                          root:root         0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -139,8 +139,8 @@
  +capabilities cap_net_raw=p
 /usr/bin/ping                                           root:root         0755
  +capabilities cap_net_raw=p
-# mtr is linked against ncurses. no suid bit, for root only:
-/usr/sbin/mtr-packet                                    root:dialout      0750
+# mtr
+/usr/sbin/mtr-packet                                    root:root         0755
 
 # exim
 /usr/sbin/exim                                          root:root         4755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -140,7 +140,7 @@
 /usr/bin/ping                                           root:root         0755
  +capabilities cap_net_raw=p
 # mtr is linked against ncurses. no suid bit, for root only:
-/usr/sbin/mtr                                           root:dialout      0750
+/usr/sbin/mtr-packet                                    root:dialout      0750
 
 # exim
 /usr/sbin/exim                                          root:root         4755


### PR DESCRIPTION
- mtr requires capabilities on `/usr/sbin/mtr-packet` instead of `/usr/sbin/mtr` since version 0.88.