### PR TITLE
list_permissions: new tool for better path configuration overview

### DIFF
--- a/tools/list_permissions.py
+++ b/tools/list_permissions.py
@@ -3,10 +3,11 @@
 # vim: ts=8 noet sw=8 sts=8 :
 
 import argparse
+import fnmatch
 from pathlib import Path
 
 parser = argparse.ArgumentParser("list assembled permissions profile information for individual paths")
-parser.add_argument("-p", "--path", type=str, help = "list only information about the given path")
+parser.add_argument("-p", "--path", type=str, default = "*", help = "list only information about the given path, supports globbing")
 
 repo_root = (Path(__file__).parent.parent).resolve()
 profile_dir = repo_root / "profiles"
@@ -105,8 +106,8 @@ pp.parse()
 max_label_len = pp.getMaxLabelLen()
 
 for path, profiles in pp.getEntries().items():
-	# apply filtering logic from command line
-	if args.path and path != args.path:
+	# apply filtering logic from command line (default matches all files)
+	if not fnmatch.fnmatch(path, args.path):
 		continue
 
 	print(path + "\n")

--- a/tools/list_permissions.py
+++ b/tools/list_permissions.py
@@ -113,29 +113,32 @@ for path, profiles in pp.getEntries().items():
 	print(path + "\n")
 
 	common_comments = extractCommonComments(profiles)
+	comment_indent = "\t" + " ".ljust(max_label_len) + "\t\t"
 
-	if common_comments:
-		for comment in common_comments:
-			print("\t" + comment)
-		print()
+	for comment in common_comments:
+		print(comment_indent + comment)
 
 	for i, profile in enumerate(profiles):
 		entry = profiles[profile]
 
+		if entry["comments"] or (i == 0 and common_comments):
+			print()
 		for line in entry["comments"]:
-			print("\t" + line)
+			print(comment_indent + line)
 
 		print("\t" + profile.ljust(max_label_len), end = '')
-
-		# if the config is equal to the previous profile's then don't
-		# print it again, to avoid printing redundant information
-		if i > 0 and list(profiles.values())[i-1]["config"] == entry["config"]:
-			print("\t\t*")
-			continue
 
 		# merge the config into a single line to allow for a simpler
 		# output structure with a single line per profile
 		config = ' '.join(entry["config"])
+
+		# if the config is equal to the previous profile's then don't
+		# print it again, to avoid printing redundant information
+		if i > 0 and list(profiles.values())[i-1]["config"] == entry["config"]:
+			print('\t\t"{spaces}"'.format(
+				spaces = ' ' * (len(config.expandtabs()) - 2)))
+			continue
+
 		print("\t\t" + config)
 	print()
 

--- a/tools/list_permissions.py
+++ b/tools/list_permissions.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+
+# vim: ts=8 noet sw=8 sts=8 :
+
+import argparse
+from pathlib import Path
+
+parser = argparse.ArgumentParser("list assembled permissions profile information for individual paths")
+parser.add_argument("-p", "--path", type=str, help = "list only information about the given path")
+
+repo_root = (Path(__file__).parent / "..").resolve()
+profile_dir = repo_root / "profiles"
+etc_dir = repo_root / "etc"
+
+PROFILE_SUFFIXES = ("easy", "secure", "paranoid")
+
+class ProfileParser:
+
+	def __init__(self, paths):
+		self.m_paths = paths
+		# a dictionary like
+		# {
+		#   "/some/path": {
+		#       "permissions.secure": {
+		#             "comments": ["# some comment", ...],
+		#             "config": [ "/some/path user:group 0441", "+capability ..." ],
+		#       ...
+		#   },
+		#   ...
+		# }
+		self.m_entries = {}
+		self.m_comments = []
+		self.m_current_path = None
+
+	def parse(self):
+		for path in self.m_paths:
+			label = path.name
+
+			with open(path) as fd:
+				self._parseFile(fd, label)
+
+	def _getDictEntry(self, path, label):
+		path_entries = self.m_entries.setdefault(path, {})
+		return path_entries.setdefault(label, {})
+
+	def _parseFile(self, fd, label):
+		for line in fd.readlines():
+
+			line = line.strip()
+
+			if line.startswith("#"):
+				# keep track of a comment block header before
+				# a path line appears. empty/other lines cause
+				# comment blocks to be reset in the else
+				# branch.
+				# Also skip empty comment lines.
+				if line != "#":
+					self.m_comments.append(line)
+			elif line.startswith("/"):
+				path, config = line.split(None, 1)
+				self.m_current_path = path
+
+				entry = self._getDictEntry(path, label)
+				entry["comments"] = self.m_comments
+				self.m_comments = []
+
+				lines = entry.setdefault("config", [])
+				lines.append(config)
+			elif line.startswith("+"):
+				entry = self._getDictEntry(self.m_current_path, label)
+				entry["config"].append(line)
+			else:
+				self.m_comments = []
+				self.m_current_path = None
+
+	def getEntries(self):
+		return self.m_entries
+
+	def getMaxLabelLen(self):
+		return max( [ len(str(label.name)) for label in self.m_paths ] )
+
+args = parser.parse_args()
+
+profiles = [profile_dir / "permissions.{}".format(profile) for profile in PROFILE_SUFFIXES]
+fixed_config = etc_dir / "permissions"
+
+pp = ProfileParser([fixed_config] + profiles)
+pp.parse()
+
+max_label_len = pp.getMaxLabelLen()
+
+for path, profiles in pp.getEntries().items():
+	# apply filtering logic from command line
+	if args.path and path != args.path:
+		continue
+
+	print(path + "\n")
+
+	# merge comments for different profiles if they are present and equal
+	merged_comment = []
+	while True:
+		comments = [ entry["comments"][0] if entry["comments"] else "" for entry in profiles.values() ]
+		if all(comments) and len(set(comments)) == 1:
+			merged_comment.append(comments[0])
+			for profile in profiles:
+				profiles[profile]["comments"].pop(0)
+		else:
+			break
+
+
+	if merged_comment:
+		for comment in merged_comment:
+			print("\t" + comment)
+		print()
+
+	for i, profile in enumerate(profiles):
+		entry = profiles[profile]
+
+		for line in entry["comments"]:
+			print("\t" + line)
+
+		print("\t" + profile.ljust(max_label_len), end = '')
+
+		# if the config is equal to the previous profile's then don't
+		# print it again, to avoid printing redundant information
+		if i > 0 and list(profiles.values())[i-1]["config"] == entry["config"]:
+			print("\t\t*")
+			continue
+
+		# merge the config into a single line to allow for a simpler
+		# output structure with a single line per profile
+		config = ' '.join(entry["config"])
+		print("\t\t" + config)
+	print()
+


### PR DESCRIPTION
Keeping track of the settings for paths spread over up to four different
configuration files is often difficult. This new script gathers
information from all available files in the repository and prints out a
condensed overview of the present configuration for individual paths.