### PR TITLE
Add /usr/libexec for cockpit-session as new path

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -362,6 +362,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+/usr/libexec/cockpit-session                            root:cockpit-wsinstance  4750
 
 # binary that launches texlive tools with group "mktex" (bsc#1171686)
 /usr/lib/mktex/public                                   root:mktex 2755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -364,6 +364,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  0750
+/usr/libexec/cockpit-session                            root:cockpit-wsinstance  0750
 
 # binary that launches texlive tools with group "mktex" (bsc#1171686)
 /usr/lib/mktex/public                                   root:mktex 0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -399,6 +399,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+/usr/libexec/cockpit-session                            root:cockpit-wsinstance  4750
 
 # binary that launches texlive tools with group "mktex" (bsc#1171686)
 /usr/lib/mktex/public                                   root:mktex 2755


### PR DESCRIPTION
Since cockpit was also moved to /usr/libexec, we need to add the new path to fix building the package