### PR TITLE
iputils/ping: remove cap_net_raw=p

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -90,7 +90,6 @@
 /usr/bin/clockdiff                                      root:root         0755
  +capabilities cap_net_raw=p
 /usr/bin/ping                                           root:root         0755
- +capabilities cap_net_raw=p
 # mtr
 /usr/sbin/mtr-packet                                    root:root         0755
  +capabilities cap_net_raw=ep

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -132,7 +132,6 @@
 /usr/bin/clockdiff                                      root:root         0755
  +capabilities cap_net_raw=p
 /usr/bin/ping                                           root:root         0755
- +capabilities cap_net_raw=p
 # mtr
 /usr/sbin/mtr-packet                                    root:root         0755
 


### PR DESCRIPTION
ping now uses IPPROTO_ICMP protocol
https://build.opensuse.org/request/show/840044
https://github.com/openSUSE/aaa_base/pull/77

Signed-off-by: Petr Vorel <pvorel@suse.cz>