### PR TITLE
Makefile: fix custom flags support when using make command line varia…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REQUIRED_CXXFLAGS=-std=c++17 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Werror -Wall -Wextra -pedantic -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wdouble-promotion  -Wshadow  -Wformat=2 -Wsign-conversion
 ifdef CXXFLAGS
-CXXFLAGS:=$(REQUIRED_CXXFLAGS) $(CXXFLAGS)
+override CXXFLAGS:=$(REQUIRED_CXXFLAGS) $(CXXFLAGS)
 else
 CXXFLAGS=$(REQUIRED_CXXFLAGS) -g -O2
 endif
@@ -19,7 +19,7 @@ CXX=g++
 # binary size
 REQUIRED_LDFLAGS=-static-libstdc++ -Wl,--as-needed
 ifdef LDFLAGS
-LDFLAGS:=$(REQUIRED_LDFLAGS) $(LDFLAGS)
+override LDFLAGS:=$(REQUIRED_LDFLAGS) $(LDFLAGS)
 else
 LDFLAGS:=$(REQUIRED_LDFLAGS)
 endif


### PR DESCRIPTION
…bles

The support for custom flags from commit
6a2be62fe046cdd70baeeb06864430801f29ffa8 is broken when make variables
are specified on the command line like `make CXXFLAGS="-my -flags"`
instead of using environment variables like `export CXXFLAGS="-my
-flags"`.

The `override` keyword is required to make the assignment of required
flags effective in the command line variable case.