### PR TITLE
profiles: finish usage of variable for polkit-agent-helper-1

### DIFF
--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -181,8 +181,7 @@
 /usr/libexec/uucp/uuxqt                                 uucp:uucp         0555
 
 # polkit new (bnc#523377)
-/usr/lib/polkit-1/polkit-agent-helper-1                 root:root         0755
-/usr/libexec/polkit-1/polkit-agent-helper-1             root:root         0755
+%{libexec_dirs}/polkit-1/polkit-agent-helper-1          root:root         0755
 /usr/bin/pkexec                                         root:root         0755
 
 # dbus-1 (#333361, #1056764, bsc#1171164)

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -208,8 +208,7 @@
 
 
 # polkit new (bnc#523377)
-/usr/lib/polkit-1/polkit-agent-helper-1                 root:root         4755
-/usr/libexec/polkit-1/polkit-agent-helper-1             root:root         4755
+%{libexec_dirs}/polkit-1/polkit-agent-helper-1          root:root         4755
 /usr/bin/pkexec                                         root:root         4755
 
 # dbus-1 (#333361 #1056764, bsc#1171164)


### PR DESCRIPTION
This path adjustment was incomplete and slipped through QA but the
permissions whitelist checker caught it.