### PR TITLE
usbauth: drop compatibility variable for libexec

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -259,8 +259,8 @@
 
 # usbauth (bsc#1066877)
 /usr/libexec/usbauth-npriv                              root:usbauth    04750
-%{libexec_dirs}/usbauth-notifier/                       root:usbauth-notifier  0750
-%{libexec_dirs}/usbauth-notifier/usbauth-notifier       root:usbauth    02755
+/usr/libexec/usbauth-notifier/                          root:usbauth-notifier  0750
+/usr/libexec/usbauth-notifier/usbauth-notifier          root:usbauth    02755
 
 # spice-gtk (bsc#1101420)
 /usr/bin/spice-client-glib-usb-acl-helper               root:kvm        04750

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -269,8 +269,8 @@
 
 # usbauth (bsc#1066877)
 /usr/libexec/usbauth-npriv                              root:usbauth    0750
-%{libexec_dirs}/usbauth-notifier/                       root:usbauth-notifier  0750
-%{libexec_dirs}/usbauth-notifier/usbauth-notifier       root:usbauth    0755
+/usr/libexec/usbauth-notifier/                          root:usbauth-notifier  0750
+/usr/libexec/usbauth-notifier/usbauth-notifier          root:usbauth    0755
 
 # spice-gtk (bsc#1101420)
 /usr/bin/spice-client-glib-usb-acl-helper               root:kvm        0750

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -298,8 +298,8 @@
 
 # usbauth (bsc#1066877)
 /usr/libexec/usbauth-npriv                              root:usbauth    04750
-%{libexec_dirs}/usbauth-notifier/                       root:usbauth-notifier  0750
-%{libexec_dirs}/usbauth-notifier/usbauth-notifier       root:usbauth    02755
+/usr/libexec/usbauth-notifier/                          root:usbauth-notifier  0750
+/usr/libexec/usbauth-notifier/usbauth-notifier          root:usbauth    02755
 
 # spice-gtk (bsc#1101420)
 /usr/bin/spice-client-glib-usb-acl-helper               root:kvm        04750


### PR DESCRIPTION
The new package will place the two paths into /usr/libexec now.