### PR TITLE
make btmp root:utmp (bsc#1050467)

### DIFF
--- a/permissions
+++ b/permissions
@@ -81,7 +81,7 @@
 /var/log/lastlog                                        root:root          644
 /var/log/faillog                                        root:root          600
 /var/log/wtmp                                           root:utmp          664
-/var/log/btmp                                           root:root          600
+/var/log/btmp                                           root:utmp          600
 /var/run/utmp                                           root:utmp          664
 /run/utmp                                           	root:utmp          664
 


### PR DESCRIPTION
Patch was merged to SLE-12-SP2 and origin/SLE-15-GA and newer, but not to SLE-12-SP4 and SLE-12-SP5 (bsc#1182899).