### PR TITLE
make lastlog root:utmp (bsc#1182899)

### DIFF
--- a/permissions
+++ b/permissions
@@ -75,16 +75,6 @@
 /run/sudo/                                          	root:root          700
 
 #
-# login tracking
-#
-/var/log/lastlog                                        root:root          644
-/var/log/faillog                                        root:root          600
-/var/log/wtmp                                           root:utmp          664
-/var/log/btmp                                           root:utmp          600
-/var/run/utmp                                           root:utmp          664
-/run/utmp                                           	root:utmp          664
-
-#
 # some device files
 #
 


### PR DESCRIPTION
systemd since v234 creates "/var/log/lastlog" as
 "/var/log/lastlog 0664 root utmp -"

https://github.com/openSUSE/systemd/commit/aff804febc31d9f0d0f98ccc3cdf9f89dd64409c
