### PR TITLE
Add prometheus-blackbox_exporter

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -319,3 +319,7 @@
 # please (bsc#1183669)
 /usr/bin/please                                         root:root 4755
 /usr/bin/pleaseedit                                     root:root 4755
+
+# prometheus-blackbox_exporter
+/usr/bin/blackbox_exporter                              root:root 0755
+ +capabilities cap_net_raw=ep

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -326,3 +326,6 @@
 # please (bsc#1183669)
 /usr/bin/please                                         root:root 0755
 /usr/bin/pleaseedit                                     root:root 0755
+
+# prometheus-blackbox_exporter
+/usr/bin/blackbox_exporter                              root:root 0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -358,3 +358,7 @@
 # please (bsc#1183669)
 /usr/bin/please                                         root:root 4755
 /usr/bin/pleaseedit                                     root:root 4755
+
+# prometheus-blackbox_exporter
+/usr/bin/blackbox_exporter                              root:root 0755
+ +capabilities cap_net_raw=ep


### PR DESCRIPTION
Adds `cap_net_raw=ep` capability as originally set in https://build.opensuse.org/request/show/922407