### PR TITLE
drop ping capabilities in favor of ICMP_PROTO sockets (bsc#1174504)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -152,10 +152,9 @@
 #
 # networking (need root for the privileged socket)
 #
+# (ping entries stay here to remove previously present cap_net_raw)
 /usr/bin/ping                                           root:root         0755
- +capabilities cap_net_raw=ep
 /usr/bin/ping6                                          root:root         0755
- +capabilities cap_net_raw=ep
 # mtr is linked against ncurses. For dialout only.
 /usr/sbin/mtr                                           root:dialout      0750
  +capabilities cap_net_raw=ep

--- a/permissions.secure
+++ b/permissions.secure
@@ -192,10 +192,9 @@
 #
 # networking (need root for the privileged socket)
 #
+# (ping entries stay here to remove previously present cap_net_raw)
 /usr/bin/ping                                           root:root         0755
- +capabilities cap_net_raw=ep
 /usr/bin/ping6                                          root:root         0755
- +capabilities cap_net_raw=ep
 # mtr is linked against ncurses. no suid bit, for root only:
 /usr/sbin/mtr                                           root:dialout      0750
 /usr/bin/rcp                                            root:root         4755


### PR DESCRIPTION
This doesn't work for fping yet in SLE-15, because it uses an older
major version of fping that doesn't contain the fallback code to
unprivileged sockets.