### PR TITLE
mount.nfs: switch from migration mode to fixed path in /usr/sbin

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -47,7 +47,7 @@
 # #66303
 /usr/bin/opiepasswd                                     root:root         4755
 # #331020
-%{sbin_dirs}/mount.nfs                                  root:root         4755
+/usr/sbin/mount.nfs                                     root:root         4755
 #
 # #133657
 /usr/bin/fusermount                                     root:trusted      4755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -65,7 +65,7 @@
 # #66303
 /usr/bin/opiepasswd                                     root:root         0755
 # #331020
-%{sbin_dirs}/mount.nfs                                  root:root         0755
+/usr/sbin/mount.nfs                                     root:root         0755
 #
 # #133657
 /usr/bin/fusermount                                     root:trusted      0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -89,7 +89,7 @@
 # #66303
 /usr/bin/opiepasswd                                     root:root         4755
 # #331020
-%{sbin_dirs}/mount.nfs                                  root:root         0755
+/usr/sbin/mount.nfs                                     root:root         0755
 #
 # #133657
 /usr/bin/fusermount                                     root:trusted      4750


### PR DESCRIPTION
linter says:

W: [path-in-migration-mode] /sbin/mount.nfs
        → exists as /usr/sbin/mount.nfs