### PR TITLE
backport whitelisting for SLE-15-SP4 (bsc#1196884)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -481,5 +481,7 @@
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
 
 # ksysguard network helper (bsc#1151190)
-/usr/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+/usr/lib/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+ +capabilities cap_net_raw=ep
+/usr/lib64/libexec/ksysguard/ksgrd_network_helper             root:root       0755
  +capabilities cap_net_raw=ep

--- a/permissions.easy
+++ b/permissions.easy
@@ -479,3 +479,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+
+# ksysguard network helper (bsc#1151190)
+/usr/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+ +capabilities cap_net_raw=ep

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -484,4 +484,5 @@
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  0750
 
 # ksysguard network helper (bsc#1151190)
-/usr/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+/usr/lib/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+/usr/lib64/libexec/ksysguard/ksgrd_network_helper             root:root       0755

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -482,3 +482,6 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  0750
+
+# ksysguard network helper (bsc#1151190)
+/usr/libexec/ksysguard/ksgrd_network_helper             root:root       0755

--- a/permissions.secure
+++ b/permissions.secure
@@ -515,3 +515,7 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+
+# ksysguard network helper (bsc#1151190)
+/usr/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+ +capabilities cap_net_raw=ep

--- a/permissions.secure
+++ b/permissions.secure
@@ -517,5 +517,7 @@
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
 
 # ksysguard network helper (bsc#1151190)
-/usr/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+/usr/lib/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+ +capabilities cap_net_raw=ep
+/usr/lib64/libexec/ksysguard/ksgrd_network_helper             root:root       0755
  +capabilities cap_net_raw=ep


### PR DESCRIPTION
This does into a new branch SLE-15-SP4. We will need to fork a new codestream for this SP.