### PR TITLE
squid: adjust pinger path, drop basic_pam_auth (bsc#1197649)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -84,9 +84,8 @@
 # squid changes from bnc#891268
 /var/cache/squid/                                       squid:root        0750
 /var/log/squid/                                         squid:root        0750
-/usr/sbin/pinger                                        root:squid        0750
+/usr/lib/squid/pinger                                   root:squid        0750
  +capabilities cap_net_raw=ep
-/usr/sbin/basic_pam_auth                                root:shadow       2750
 
 
 # still to be converted to utempter

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -99,8 +99,7 @@
 # /quid changes from bnc#891268
 /var/cache/squid/                                       squid:root        0750
 /var/log/squid/                                         squid:root        0750
-/usr/sbin/pinger                                        root:squid        0750
-/usr/sbin/basic_pam_auth                                root:shadow       0750
+/usr/lib/squid/pinger                                   root:squid        0750
 
 
 # still to be converted to utempter

--- a/permissions.secure
+++ b/permissions.secure
@@ -124,9 +124,8 @@
 # squid changes from bnc#891268
 /var/cache/squid/                                       squid:root        0750
 /var/log/squid/                                         squid:root        0750
-/usr/sbin/pinger                                        root:squid        0750
+/usr/lib/squid/pinger                                   root:squid        0750
  +capabilities cap_net_raw=ep
-/usr/sbin/basic_pam_auth                                root:shadow       2750
 
 
 # still to be converted to utempter


### PR DESCRIPTION
pinger has been moved into the libexec dir on SLE-15-SP4.

Just like in Factory the basic_pam_auth permissions don't make any
sense, therefore drop them rather. See bug reference for details.