### PR TITLE
static permissions: remove deprecated bind / named chroot entries (bs…

### DIFF
--- a/permissions
+++ b/permissions
@@ -157,12 +157,6 @@
 /lib/udev/devices/tty                                   root:tty          0666
 /lib/udev/devices/zero                                  root:root         0666
 
-#
-# named chroot (#438045)
-#
-/var/lib/named/dev/null                                 root:root         0666
-/var/lib/named/dev/random                               root:root         0666
-
 # opiesu is not allowed setuid root as code quality is bad (bnc#882035)
 /usr/bin/opiesu						root:root         0755
 # wodim is not allowed setuid root as cd burning does not strictly require


### PR DESCRIPTION
…c#1200747)

bind-chroot has been dropped from SLE-15-SP4 in favor of systemd
isolation features. Also directory permissions are handled by a
systemd-tmpfiles configuration file now.

These entries generate chkstat warning messages as outlined in the
referenced bug report.