### PR TITLE
apptainer: fix starter-suid location

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -355,7 +355,7 @@
 /usr/lib/singularity/bin/starter-suid                   root:singularity  4750
 
 # apptainer (Singularity successor) (bsc#1196145)
-/usr/libexec/apptainer/bin/starter-suid                 root:apptainer    4750
+/usr/lib/apptainer/bin/starter-suid                     root:apptainer    4750
 
 #
 # XXX: / -> /usr merge and sbin -> bin merge

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -365,7 +365,7 @@
 /usr/lib/singularity/bin/starter-suid                   root:singularity  0750
 
 # apptainer (Singularity successor) (bsc#1196145)
-/usr/libexec/apptainer/bin/starter-suid                 root:apptainer    0750
+/usr/lib/apptainer/bin/starter-suid                     root:apptainer    0750
 
 #
 # XXX: / -> /usr merge and sbin -> bin merge

--- a/permissions.secure
+++ b/permissions.secure
@@ -395,7 +395,7 @@
 /usr/lib/singularity/bin/starter-suid                   root:singularity  4750
 
 # apptainer (Singularity successor) (bsc#1196145)
-/usr/libexec/apptainer/bin/starter-suid                 root:apptainer    4750
+/usr/lib/apptainer/bin/starter-suid                     root:apptainer    4750
 
 #
 # XXX: / -> /usr merge and sbin -> bin merge


### PR DESCRIPTION
The cherry pick from the master branch is not working on SLE-15-SP4,
because %libexec is still /usr/lib there.