### PR TITLE
profiles: Initial support of util-linux-mini (PED-1007)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -208,9 +208,17 @@
 # apptainer (Singularity successor) (bsc#1196145)
 /usr/libexec/apptainer/bin/starter-suid                 root:apptainer    4750
 
+# util-linux
 /usr/bin/su                                             root:root         4755
 /usr/bin/mount                                          root:root         4755
 /usr/bin/umount                                         root:root         4755
+# util-linux-mini
+/usr/libexec/build/staging/bin/su                       root:root         4755
+/usr/libexec/build/staging/bin/mount                    root:root         4755
+/usr/libexec/build/staging/bin/umount                   root:root         4755
+/usr/libexec/build/staging/bin/wall                     root:tty          2755
+/usr/libexec/build/staging/bin/write                    root:tty          2755
+
 
 # cdrecord of cdrtools from Joerg Schilling (bnc#550021)
 # Please note that additional capabilities are provided only for reliable

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -222,9 +222,16 @@
 # apptainer (Singularity successor) (bsc#1196145)
 /usr/libexec/apptainer/bin/starter-suid                 root:apptainer    0750
 
+# util-linux
 /usr/bin/su                                             root:root         0755
 /usr/bin/mount                                          root:root         0755
 /usr/bin/umount                                         root:root         0755
+# util-linux-mini
+/usr/libexec/build/staging/bin/su                       root:root         0755
+/usr/libexec/build/staging/bin/mount                    root:root         0755
+/usr/libexec/build/staging/bin/umount                   root:root         0755
+/usr/libexec/build/staging/bin/wall                     root:tty          0755
+/usr/libexec/build/staging/bin/write                    root:tty          0755
 
 # cdrecord of cdrtools from Joerg Schilling (bnc#550021)
 # in paranoid mode, no provisions are made for reliable cd burning, as admins

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -250,9 +250,16 @@
 # apptainer (Singularity successor) (bsc#1196145)
 /usr/libexec/apptainer/bin/starter-suid                 root:apptainer    4750
 
+# util-linux
 /usr/bin/su                                             root:root         4755
 /usr/bin/mount                                          root:root         4755
 /usr/bin/umount                                         root:root         4755
+# util-linux-mini
+/usr/libexec/build/staging/bin/su                       root:root         4755
+/usr/libexec/build/staging/bin/mount                    root:root         4755
+/usr/libexec/build/staging/bin/umount                   root:root         4755
+/usr/libexec/build/staging/bin/wall                     root:tty          0755
+/usr/libexec/build/staging/bin/write                    root:tty          0755
 
 # cdrecord of cdrtools from Joerg Schilling (bnc#550021)
 # in secure mode, no provisions are made for reliable cd burning, as admins


### PR DESCRIPTION
New packaging style of a staging util-linux-mini package requires files in a dedicated directory.
Permissions have to be kept.
For more see [https://build.opensuse.org/request/show/1000736](https://build.opensuse.org/request/show/1000736)