### PR TITLE
Revert "drop ping capabilities in favor of ICMP_PROTO sockets (bsc#11…

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -152,9 +152,10 @@
 #
 # networking (need root for the privileged socket)
 #
-# (ping entries stay here to remove previously present cap_net_raw)
 /usr/bin/ping                                           root:root         0755
+ +capabilities cap_net_raw=ep
 /usr/bin/ping6                                          root:root         0755
+ +capabilities cap_net_raw=ep
 # mtr is linked against ncurses. For dialout only.
 /usr/sbin/mtr                                           root:dialout      0750
  +capabilities cap_net_raw=ep

--- a/permissions.secure
+++ b/permissions.secure
@@ -192,9 +192,10 @@
 #
 # networking (need root for the privileged socket)
 #
-# (ping entries stay here to remove previously present cap_net_raw)
 /usr/bin/ping                                           root:root         0755
+ +capabilities cap_net_raw=ep
 /usr/bin/ping6                                          root:root         0755
+ +capabilities cap_net_raw=ep
 # mtr is linked against ncurses. no suid bit, for root only:
 /usr/sbin/mtr                                           root:dialout      0750
 /usr/bin/rcp                                            root:root         4755


### PR DESCRIPTION
…74504)"

This reverts commit d17f06caf6c794a904543df11c7a4f91b464bd7f.

SLE-15-SP2 has troubles with the ICMP_PROTO sockets (bsc#1204137)