### PR TITLE
permissions for enlightenment helper on 32bit arches (bsc#1194047)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -477,6 +477,7 @@
 /usr/lib/mktex/public                                   root:mktex 2755
 
 # enlightenment privileged desktop operations (bsc#1169238)
+/usr/lib/enlightenment/utils/enlightenment_system       root:root  4755
 /usr/lib64/enlightenment/utils/enlightenment_system     root:root  4755
 
 # setuid bit for cockpit (bsc#1169614)

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -480,6 +480,7 @@
 /usr/lib/mktex/public                                   root:mktex 0755
 
 # enlightenment privileged desktop operations (bsc#1169238)
+/usr/lib/enlightenment/utils/enlightenment_system       root:root  0755
 /usr/lib64/enlightenment/utils/enlightenment_system     root:root  0755
 
 # setuid bit for cockpit (bsc#1169614)

--- a/permissions.secure
+++ b/permissions.secure
@@ -513,6 +513,7 @@
 /usr/lib/mktex/public                                   root:mktex 2755
 
 # enlightenment privileged desktop operations (bsc#1169238)
+/usr/lib/enlightenment/utils/enlightenment_system       root:root  4755
 /usr/lib64/enlightenment/utils/enlightenment_system     root:root  4755
 
 # setuid bit for cockpit (bsc#1169614)


### PR DESCRIPTION
On main/master branch this was fixed more elegantly via %{lib_dirs}, which however is not yet available on SLE. Duplicate the entries instead.