### PR TITLE
profiles: remove outdated kdesud, apptainer entries

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -120,9 +120,6 @@
 # framebuffer terminal emulator (japanese)
 /usr/bin/jfbterm                                        root:tty          6755
 
-# kdesud (bsc#872276)
-/usr/libexec/kf5/kdesud                                 root:nogroup      2755
-
 #
 # amanda
 #
@@ -204,9 +201,6 @@
 
 # singularity version 3 (bsc#1128598)
 /usr/libexec/singularity/bin/starter-suid               root:singularity  4750
-
-# apptainer (Singularity successor) (bsc#1196145)
-/usr/libexec/apptainer/bin/starter-suid                 root:apptainer    4750
 
 /usr/bin/su                                             root:root         4755
 /usr/bin/mount                                          root:root         4755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -134,9 +134,6 @@
 # framebuffer terminal emulator (japanese).
 /usr/bin/jfbterm                                        root:tty          0755
 
-# kdesud (bsc#872276)
-/usr/libexec/kf5/kdesud                                 root:nogroup      0755
-
 #
 # amanda
 #
@@ -218,9 +215,6 @@
 
 # singularity version 3 (bsc#1128598)
 /usr/libexec/singularity/bin/starter-suid               root:singularity  0750
-
-# apptainer (Singularity successor) (bsc#1196145)
-/usr/libexec/apptainer/bin/starter-suid                 root:apptainer    0750
 
 /usr/bin/su                                             root:root         0755
 /usr/bin/mount                                          root:root         0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -160,9 +160,6 @@
 # framebuffer terminal emulator (japanese)
 /usr/bin/jfbterm                                        root:tty          0755
 
-# kdesud (bsc#872276)
-/usr/libexec/kf5/kdesud                                 root:nogroup      2755
-
 #
 # amanda
 #
@@ -246,9 +243,6 @@
 
 # singularity version 3 (bsc#1128598)
 /usr/libexec/singularity/bin/starter-suid               root:singularity  4750
-
-# apptainer (Singularity successor) (bsc#1196145)
-/usr/libexec/apptainer/bin/starter-suid                 root:apptainer    4750
 
 /usr/bin/su                                             root:root         4755
 /usr/bin/mount                                          root:root         4755


### PR DESCRIPTION
- apptainer is now supporting a mode without setuid-root (bsc#1206521)
- kdesud also supports operation without setgid (bsc#1206522)