### PR TITLE
Backport postfix to Leap 15.2 (bsc#1206738)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -483,3 +483,6 @@
  +capabilities cap_net_raw=ep
 /usr/lib64/libexec/ksysguard/ksgrd_network_helper             root:root       0755
  +capabilities cap_net_raw=ep
+
+# postfix (bsc#1206738 bsc#1201385)
+/usr/sbin/postlog                                       root:maildrop 2755

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -483,3 +483,6 @@
 # ksysguard network helper (bsc#1151190)
 /usr/lib/libexec/ksysguard/ksgrd_network_helper             root:root       0755
 /usr/lib64/libexec/ksysguard/ksgrd_network_helper             root:root       0755
+
+# postfix (bsc#1206738 bsc#1201385)
+/usr/sbin/postlog                                       root:maildrop 0755

--- a/permissions.secure
+++ b/permissions.secure
@@ -519,3 +519,6 @@
  +capabilities cap_net_raw=ep
 /usr/lib64/libexec/ksysguard/ksgrd_network_helper             root:root       0755
  +capabilities cap_net_raw=ep
+
+# postfix (bsc#1206738 bsc#1201385)
+/usr/sbin/postlog                                       root:maildrop 2755


### PR DESCRIPTION
Backport postfix SUID whitelisting to Leap 15.2, as requested in https://bugzilla.suse.com/show_bug.cgi?id=1206738
Most recent audit: https://bugzilla.opensuse.org/show_bug.cgi?id=1201385