### PR TITLE
Backport postfix to SLE-15-SP2 (bsc#1206738)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -480,3 +480,6 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+
+# postfix (bsc#1206738 bsc#1201385)
+/usr/sbin/postlog                                       root:maildrop 2755

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -482,3 +482,6 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  0750
+
+# postfix (bsc#1206738 bsc#1201385)
+/usr/sbin/postlog                                       root:maildrop 0755

--- a/permissions.secure
+++ b/permissions.secure
@@ -516,3 +516,6 @@
 
 # setuid bit for cockpit (bsc#1169614)
 /usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+
+# postfix (bsc#1206738 bsc#1201385)
+/usr/sbin/postlog                                       root:maildrop 2755


### PR DESCRIPTION
Backport postfix SUID whitelisting to SLE-15-SP2, as requested in https://bugzilla.suse.com/show_bug.cgi?id=1206738
Most recent audit: https://bugzilla.opensuse.org/show_bug.cgi?id=1201385