### PR TITLE
profiles: whitelist kismet capabilities (bsc#1200954)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -316,3 +316,10 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 2755
+
+# kismet (bsc#1200954, bsc#1207654)
+/usr/bin/kismet_cap_linux_bluetooth                     root:kismet 0750
+ +capabilities cap_net_raw,cap_net_admin=ep
+
+/usr/bin/kismet_cap_linux_wifi                          root:kismet 0750
+ +capabilities cap_net_raw,cap_net_admin=ep

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -324,3 +324,8 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 0755
+
+# kismet (bsc#1200954, bsc#1207654)
+/usr/bin/kismet_cap_linux_bluetooth                     root:kismet 0750
+
+/usr/bin/kismet_cap_linux_wifi                          root:kismet 0750

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -355,3 +355,10 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 2755
+
+# kismet (bsc#1200954, bsc#1207654)
+/usr/bin/kismet_cap_linux_bluetooth                     root:kismet 0750
+ +capabilities cap_net_raw,cap_net_admin=ep
+
+/usr/bin/kismet_cap_linux_wifi                          root:kismet 0750
+ +capabilities cap_net_raw,cap_net_admin=ep


### PR DESCRIPTION
This daemon used to run as root but it actually only required two file capabilities.
https://bugzilla.suse.com/show_bug.cgi?id=1207654