### PR TITLE
shadow: newgidmap,newuidmap: use capabilities (bsc#1208309)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -237,9 +237,11 @@
 #
 /usr/sbin/suexec            				root:root       0755
 
-# newgidmap / newuidmap (bsc#979282, bsc#1048645)
-/usr/bin/newgidmap					root:shadow	4755
-/usr/bin/newuidmap					root:shadow	4755
+# newgidmap / newuidmap (bsc#979282, bsc#1048645, bsc#1208309)
+/usr/bin/newgidmap					root:root	0755
+ +capabilities cap_setgid=ep
+/usr/bin/newuidmap					root:root	0755
+ +capabilities cap_setuid=ep
 
 # kwayland (bsc#1062182)
 /usr/bin/kwin_wayland					root:root	0755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -249,9 +249,9 @@
 #
 /usr/sbin/suexec            				root:root       0755
 
-# newgidmap / newuidmap (bsc#979282, bsc#1048645)
-/usr/bin/newgidmap					root:shadow	0755
-/usr/bin/newuidmap					root:shadow	0755
+# newgidmap / newuidmap (bsc#979282, bsc#1048645, bsc#1208309)
+/usr/bin/newgidmap					root:root	0755
+/usr/bin/newuidmap					root:root	0755
 
 # kwayland (bsc#1062182)
 /usr/bin/kwin_wayland					root:root	0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -277,9 +277,11 @@
 #
 /usr/sbin/suexec             				root:root       0755
 
-# newgidmap / newuidmap (bsc#979282, bsc#1048645)
-/usr/bin/newgidmap					root:shadow	4755
-/usr/bin/newuidmap					root:shadow	4755
+# newgidmap / newuidmap (bsc#979282, bsc#1048645, bsc#1208309)
+/usr/bin/newgidmap					root:root	0755
+ +capabilities cap_setgid=ep
+/usr/bin/newuidmap					root:root	0755
+ +capabilities cap_setuid=ep
 
 # kwayland (bsc#1062182)
 /usr/bin/kwin_wayland					root:root	0755


### PR DESCRIPTION
- replace setuid-root by cap_setgid and cap_setuid respectively. This lowers the attack surface somewhat and seems also to improve some application use cases (see bug).
- drop shadow group, that should have never been there, a kind of artifact from the initial entry years ago.