### PR TITLE
profiles: remove dropped pppoe-wrapper

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -92,12 +92,6 @@
 /usr/sbin/exim                                          root:root         4755
 
 #
-# dialup networking programs
-#
-/usr/sbin/pppoe-wrapper                                 root:dialout      4750
-
-
-#
 # linux text console utilities
 #
 # setuid needed on the text console to set the terminal content on ctrl-o

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -107,12 +107,6 @@
 /usr/sbin/exim                                          root:root         0755
 
 #
-# dialup networking programs
-#
-/usr/sbin/pppoe-wrapper                                 root:dialout      0750
-
-
-#
 # linux text console utilities
 #
 # setuid needed on the text console to set the terminal content on ctrl-o

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -132,12 +132,6 @@
 /usr/sbin/exim                                          root:root         4755
 
 #
-# dialup networking programs
-#
-/usr/sbin/pppoe-wrapper                                 root:dialout      4750
-
-
-#
 # linux text console utilities
 # 
 # setuid needed on the text console to set the terminal content on ctrl-o


### PR DESCRIPTION
In a recent major update to rp-pppoe 4.0 (sr#1087186) the pppoe-wrapper has been dropped. Upstream commit:

https://salsa.debian.org/dskoll/rp-pppoe/-/commit/4330e82493a3cec7c78fe3cbeca964cf0d8b8795