### PR TITLE
CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC allows modification without /proc

### DIFF
--- a/man/chkstat.8
+++ b/man/chkstat.8
@@ -67,6 +67,12 @@ and instead of all files listed in the permissions files.
 .IR \-\-root\ directory
 Check files relative to the specified directory.
 .PP
+.SH "ENVIRONMENT VARIABLES"
+.B CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC
+Allow to operate without mounted /proc filesystem. This is an unsafe mode that must only
+be used in controlled environments where unprivileged users can't influence filesystem
+operation.
+.PP
 .SH EXAMPLES
 .PP
 .B chkstat --set /usr/share/permissions/permissions /usr/share/permissions/permissions.secure

--- a/src/chkstat.h
+++ b/src/chkstat.h
@@ -65,6 +65,9 @@ protected: // functions
     /// Checks whether /proc is mounted and returns the result.
     bool isProcMounted() const;
 
+    /// Checks if changes are allowed to be applied without /proc filesystem
+    bool allowNoProc() const;
+
     /// Prints an introductory text describing the active configuration.
     void printHeader();
 
@@ -87,6 +90,17 @@ protected: // data
      * overridden by runtime context e.g. a missing /proc or sysconfig.
      **/
     bool m_apply_changes = false;
+
+    /// Allow operation without mounted /proc file system.
+    /**
+     * In normal operation we fall back to a read only mode if /proc is not
+     * available because securely operating on arbitrary filesystems is not
+     * possible then. In some configurations /proc is not available (e.g.
+     * container setups) but changes should be applied anyway.
+     * The caller needs to ensure that no unpriviled user can influence the
+     * operation in nefarious ways
+     **/
+    const bool m_allow_no_proc = false;
 
     /// The predefined profile names shipped with permissions.
     static constexpr const char * const PREDEFINED_PROFILES[] = {"easy", "secure", "paranoid"};

--- a/src/entryproc.cpp
+++ b/src/entryproc.cpp
@@ -46,10 +46,10 @@ bool EntryProcessor::process(const bool have_proc) {
             // all symlinks, 'fd' can't refer to a symlink which we'd have to worry might get followed.)
             m_safe_path = std::string("/proc/self/fd/") + std::to_string(m_fd.get());
         } else {
-            // fall back to plain path-access for read-only operation. (this much is fine)
-            // we only report errors below, m_apply_changes is set to false in this case.
+            // No proc filesystem is available.
+            // Unless the environment variable is set we only report errors below, m_apply_changes is set to false in this case.
+            // otherwise we operate insecurely and trust that this is done only in safe environments, see bsc#1219736
             m_safe_path = m_entry.file;
-            assert(!m_apply_changes);
         }
 
         if (!getCapabilities()) {

--- a/src/environment.h
+++ b/src/environment.h
@@ -1,0 +1,6 @@
+#pragma once
+
+const std::string ENVVAR_ALLOW_NO_PROC = "CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC";
+const std::string ENVVAR_PRETEND_NO_PROC = "CHKSTAT_PRETEND_NO_PROC";
+
+// vim: et ts=4 sts=4 sw=4 :


### PR DESCRIPTION
In some environments /proc is not available (details are available in https://bugzilla.suse.com/show_bug.cgi?id=1219736). This introduces the ability to force an insecure operation mode by settting CHKSTAT_FORCE_INSECURE_MODE_IF_NO_PROC