### PR TITLE
global: rename chkstat to permctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ this:
     meson setup build
 
     cd build
-    # building of the chkstat program
+    # building of the permctl program
     meson compile
 
     # optional installation
@@ -28,7 +28,7 @@ this:
 
 # Known limitations
 
-chkstat doesn't remove permissions that were removed from the profiles. So if
+permctl doesn't remove permissions that were removed from the profiles. So if
 an entry is removed like with https://github.com/openSUSE/permissions/pull/100
 there needs to be an update of the package that caries the binary to take
 effect. ATM we don't see this as major problem and also don't have a good way

--- a/etc/permissions
+++ b/etc/permissions
@@ -5,7 +5,7 @@
 #
 # Author: Roman Drahtmueller <draht@suse.de>, 2001
 #
-# This file is used by chkstat (and indirectly by various RPM scripts)
+# This file is used by permctl (and indirectly by various RPM scripts)
 # to check or set the modes and ownerships of files and directories in the installation.
 #
 # There is a set of files with similar meaning in a SUSE installation:
@@ -21,10 +21,10 @@
 # <file> <owner>:<group> <permission>
 #
 # How it works:
-# To change an entry copy the line to permissions.local, modify it
-# to suit your needs and call "chkstat --system"
+# To change an entry, copy the line to permissions.local, modify it
+# to suit your needs and call "permctl --system"
 #
-# chkstat uses the variable PERMISSION_SECURITY from
+# permctl uses the variable PERMISSION_SECURITY from
 # /etc/sysconfig/security to determine which security level to
 # apply.
 # In addition to the central files listed above the directory

--- a/etc/permissions.local
+++ b/etc/permissions.local
@@ -2,10 +2,10 @@
 # /etc/permissions.local
 #
 # After editing this file run
-#	chkstat --system --set
+#	permctl --system --set
 # to apply the changes.
 #
-# This file is used by chkstat (and indirectly by various RPM package scripts)
+# This file is used by permctl (and indirectly by various RPM package scripts)
 # to check or set the modes and ownerships of files and directories in
 # the installation. It has priority over the distribution defaults in
 # /usr/share/permissions.

--- a/man/permctl.8
+++ b/man/permctl.8
@@ -1,31 +1,32 @@
 .\"
-.\" SUSE man page for chkstat
+.\" SUSE man page for permctl
 .\"
 .\" Author: Ruediger Oertel
 .\"
-.TH CHKSTAT 8 "2010-11-09" "SUSE Linux" "Tool to check and set file permissions"
+.TH PERMCTL 8 "2024-04-23" "SUSE Linux" "Tool to check and set file permissions"
 .\"
 .UC 8
 .SH NAME
 .\"
-chkstat \- Tool to check and set file permissions
+permctl \- Tool to check and set file permissions
 .SH SYNOPSIS
 .\"
-.B chkstat
+.B permctl
 .RB [OPTIONS]
 .B <permission-files...>
 
-.B chkstat
+.B permctl
 .RB \-\-system
 .RB [OPTIONS]
 .B <files...>
 .\"
 .SH DESCRIPTION
 The program
-.I /usr/bin/chkstat
-is a tool to check and set file permissions.
+.I /usr/bin/permctl
+is a tool to check and set file permissions. It was previously called chkstat,
+but has been renamed to better describe its purpose.
 .PP
-chkstat can either operate in system mode or on individually
+permctl can either operate in system mode or on individually
 specified permission files. In system mode, \fI/etc/sysconfig/security\fR
 determines which level to use and whether to actually apply
 permission changes.
@@ -68,20 +69,20 @@ and instead of all files listed in the permissions files.
 Check files relative to the specified directory.
 .PP
 .SH "ENVIRONMENT VARIABLES"
-.B CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC
+.B PERMCTL_ALLOW_INSECURE_MODE_IF_NO_PROC
 Allow to operate without mounted /proc filesystem. This is an unsafe mode that must only
 be used in controlled environments where unprivileged users can't influence filesystem
 operation.
 .PP
 .SH EXAMPLES
 .PP
-.B chkstat --set /usr/share/permissions/permissions /usr/share/permissions/permissions.secure
+.B permctl --set /usr/share/permissions/permissions /usr/share/permissions/permissions.secure
 .PP
 parses the files /usr/share/permissions/permissions and
 /usr/share/permissions/permissions and sets the
 access mode and the user- and group memberships for each file listed.
 .PP
-.B chkstat --system /bin/ping
+.B permctl --system /bin/ping
 .PP
 Run in system mode and only correct permissions of /bin/ping
 .
@@ -101,4 +102,3 @@ Reinhold Sojer, Ruediger Oertel, Michael Schroeder, Ludwig Nussel
 Useful changes and additions by Tobias Burnus
 .PP
 Major refactoring by Matthias Gerstner, Malte Kraus
-

--- a/man/permissions.5
+++ b/man/permissions.5
@@ -6,7 +6,7 @@
 .SH "NAME"
 permission - default permission settings
 .SH "SYNOPSIS"
-The chkstat program sets permissions and ownerships according to the
+The permctl program sets permissions and ownerships according to the
 permission files\.
 .SH "DESCRIPTION"
 .PP
@@ -28,7 +28,7 @@ The file name in the first column can contain contain variables as defined in
 the \fIvariables.conf\fR file.
 .br
 A variable expands to one or more alternative path segments that relate to the
-same program or file.  chkstat will look in each possible path 
+same program or file. permctl will look in each possible path
 resulting from the variable expansion and apply the permissions accordingly.
 .PP
 The variables.conf file will ignore empty lines, whitespace only lines or
@@ -76,7 +76,7 @@ sub_dirs = prog_v1 prog_v2
 .br
 %{lib_dirs}/%{sub_dirs}/libsomething.so root:root 04755
 .PP
-Will cause chkstat to try and apply the given permission to all of the
+Will cause permctl to try and apply the given permission to all of the
 following paths:
 .PP
 \- /lib/prog_v1/libsomething.so
@@ -105,7 +105,7 @@ following paths:
 /etc/permissions\.local
 .br
 .SH "SEE ALSO"
-chkstat(8)
+permctl(8)
 .sp
 .SH "AUTHOR"
 Written by Ludwig Nussel

--- a/meson.build
+++ b/meson.build
@@ -25,8 +25,8 @@ if get_option('testbuild')
   endforeach
 endif
 
-executable('chkstat', [
-    'src/chkstat.cpp',
+executable('permctl', [
+    'src/permctl.cpp',
     'src/cmdline.cpp',
     'src/entryproc.cpp',
     'src/formatting.cpp',
@@ -43,7 +43,9 @@ executable('chkstat', [
   install: true
 )
 
-install_man('man/chkstat.8')
+# backward compatibility symlink
+install_symlink('chkstat', pointing_to: 'permctl', install_dir: 'bin')
+install_man('man/permctl.8')
 install_man('man/permissions.5')
 install_data(sources: 'etc/sysconfig.security', install_dir: 'share/fillup-templates')
 install_data(sources: 'zypper-plugin/permissions.py', install_dir: 'lib/zypp/plugins/commit')

--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -18,7 +18,7 @@ public: // data
     TCLAP::SwitchArg verbose;
     TCLAP::SwitchArg print_variables;
 
-    // NOTE: previously chkstat allowed multiple specifications of value
+    // NOTE: old chkstat allowed multiple specifications of value
     // switches like --level and --root but actually only used the last
     // occurrence on the command line. In theory this is a backward
     // compatibility break, but it's also kind of a bug.

--- a/src/entryproc.cpp
+++ b/src/entryproc.cpp
@@ -78,7 +78,7 @@ bool EntryProcessor::process(const bool have_proc) {
 
         if (m_euid != 0) {
             // only attempt to change the owner if we're actually privileged
-            // to do so (chkstat also supports to run as a regular user within
+            // to do so (permctl also supports to run as a regular user within
             // certain limits)
             m_need_fix_ownership = false;
         }
@@ -228,7 +228,7 @@ EntryProcessor::OpenRes EntryProcessor::safeOpen() {
 
         if (m_file_status.isLink()) {
             // If the path configured in the permissions configuration is a symlink, we don't follow it.
-            // This is to emulate legacy behaviour: old insecure versions of chkstat did a simple lstat(path) as 'protection' against malicious symlinks.
+            // This is to emulate legacy behaviour: old insecure versions of permctl/chkstat did a simple lstat(path) as 'protection' against malicious symlinks.
             if (is_final_path_element)
                return OpenRes::SKIP;
             else if (++link_count >= 256) {

--- a/src/environment.h
+++ b/src/environment.h
@@ -1,6 +1,11 @@
 #pragma once
 
-const std::string ENVVAR_ALLOW_NO_PROC = "CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC";
-const std::string ENVVAR_PRETEND_NO_PROC = "CHKSTAT_PRETEND_NO_PROC";
+#include <array>
+
+// for backward compatibility still support the CHKSTAT prefix
+constexpr std::array<const char*, 2> ENVVARS_ALLOW_NO_PROC{{
+        "PERMCTL_ALLOW_INSECURE_MODE_IF_NO_PROC",
+        "CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC"}};
+constexpr const char *ENVVAR_PRETEND_NO_PROC = "PERMCTL_PRETEND_NO_PROC";
 
 // vim: et ts=4 sts=4 sw=4 :

--- a/src/permctl.h
+++ b/src/permctl.h
@@ -13,11 +13,11 @@
 #include <utility>
 #include <vector>
 
-/// Main application class for Chkstat.
-class Chkstat {
+/// Main application class for permctl.
+class PermCtl {
 public: // functions
 
-    Chkstat(const CmdlineArgs &args);
+    PermCtl(const CmdlineArgs &args);
 
     int run();
 
@@ -64,9 +64,6 @@ protected: // functions
 
     /// Checks whether /proc is mounted and returns the result.
     bool isProcMounted() const;
-
-    /// Checks if changes are allowed to be applied without /proc filesystem
-    bool allowNoProc() const;
 
     /// Prints an introductory text describing the active configuration.
     void printHeader();

--- a/tests/regtest.py
+++ b/tests/regtest.py
@@ -2,9 +2,9 @@
 
 import sys
 
-from base import ChkstatRegtest
+from base import PermctlRegtest
 from tests import tests
 
-test = ChkstatRegtest()
+test = PermctlRegtest()
 res = test.run(tests)
 sys.exit(res)

--- a/zypper-plugin/README.md
+++ b/zypper-plugin/README.md
@@ -1,6 +1,6 @@
 # permissions-zypp-plugin
 
-This is a simple zypper commit plugin. Its purpose is to call `chkstat
+This is a simple zypper commit plugin. Its purpose is to call `permctl
 --system` in case a file is installed that is also listed in
 `/etc/permissions.local`. This makes it possible to use permissions.local for
 applying custom permissions for files that are managed by zypper. Otherwise

--- a/zypper-plugin/permissions.py
+++ b/zypper-plugin/permissions.py
@@ -31,7 +31,7 @@
 #
 # The COMMITBEGIN and COMMITEND hooks allow to inspect which packages are
 # installed or removed. We can't look at individual files, though. Therefore
-# we have to blindly call chkstat at the end of each transaction that adds one
+# we have to blindly call permctl at the end of each transaction that adds one
 # or more packages.
 
 import sys
@@ -58,14 +58,14 @@ def callCheckstat():
     # is not disabled in /etc/sysconfig/security. If it is then the admin
     # hopefuly knows what they are doing on their own.
     res = subprocess.call(
-        ['/usr/bin/chkstat', '--system'],
+        ['/usr/bin/permctl', '--system'],
         shell=False,
         close_fds=True,
         stdout=sys.stderr
     )
 
     if res != 0:
-        log("chkstat failed with exit code", res)
+        log("permctl failed with exit code", res)
 
 
 class PermissionsPlugin(zypp_plugin.Plugin):
@@ -79,9 +79,9 @@ class PermissionsPlugin(zypp_plugin.Plugin):
         # part of this transaction
         #self.m_matches = set()
         # This is actually not needed currently. In the first place I wanted
-        # to only call chkstat when a file was added or replaced that is
+        # to only call permctl when a file was added or replaced that is
         # listed in permissions.local. Since this information is not easily
-        # available from zypper we always call chkstat instead.
+        # available from zypper we always call permctl instead.
         #self._parsePermissions("/etc/permissions.local", "local")
 
     def _parsePermissions(self, path, label):


### PR DESCRIPTION
While the people developing chkstat got used to its name, it doesn't really convey any sensible meaning to the end user. To match its purpose and the rest of the permissions package better, rename it to "permctl".

While doing so, some spots of backwards compatibility need to remain. This affects the recently introduced
CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC environment variable. A `chkstat` symlink is also installed to avoid breaking a ton of scripts. Removing all old invocation styles will take its time.

To inform interactive users about the name change, a warning will be printed on stderr, if they invoke it using the compatibility symlink.