### PR TITLE
man pages: use asciidoc for generating man pages

### DIFF
--- a/man/permctl.8
+++ b/man/permctl.8
@@ -1,104 +1,144 @@
+'\" t
+.\"     Title: permctl
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 04/24/2024
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
 .\"
-.\" SUSE man page for permctl
-.\"
-.\" Author: Ruediger Oertel
-.\"
-.TH PERMCTL 8 "2024-04-23" "SUSE Linux" "Tool to check and set file permissions"
-.\"
-.UC 8
-.SH NAME
-.\"
-permctl \- Tool to check and set file permissions
-.SH SYNOPSIS
-.\"
-.B permctl
-.RB [OPTIONS]
-.B <permission-files...>
-
-.B permctl
-.RB \-\-system
-.RB [OPTIONS]
-.B <files...>
-.\"
-.SH DESCRIPTION
-The program
-.I /usr/bin/permctl
-is a tool to check and set file permissions. It was previously called chkstat,
-but has been renamed to better describe its purpose.
+.TH "PERMCTL" "8" "04/24/2024" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+permctl \- tool to check and set file permissions
+.SH "SYNOPSIS"
+.sp
+\fBpermctl\fR [OPTIONS] <permission\-files\&...>
+.sp
+\fBpermctl\fR \-\-system [OPTIONS] <files\&...>
+.SH "DESCRIPTION"
+.sp
+The program \fI/usr/bin/permctl\fR is a tool to check and set file permissions\&. It was previously called chkstat, but has been renamed to better describe its purpose\&.
+.sp
+permctl can either operate in system mode or on individually specified permission files\&. In system mode, \fI/etc/sysconfig/security\fR determines which level to use and whether to actually apply permission changes\&.
+.SH "OPTIONS"
 .PP
-permctl can either operate in system mode or on individually
-specified permission files. In system mode, \fI/etc/sysconfig/security\fR
-determines which level to use and whether to actually apply
-permission changes.
+\fB\-\-system\fR
+.RS 4
+Run in system mode\&. Parses
+\fI/etc/sysconfig/security\fR
+to determine which security level to use (\fIPERMISSION_SECURITY\fR) and whether to set or merely warn about permission changes (\fICHECK_PERMISSIONS\fR)\&. In system mode non\-option arguments refer to files\&. I\&.e\&. just as if the \-\-examine option was specified for them\&.
+.RE
 .PP
-.\"
-.SS OPTIONS
-.TP
-.IR \-\-system
-Run in system mode. Parses \fI/etc/sysconfig/security\fR to
-determine which security level to use (\fIPERMISSION_SECURITY\fR)
-and whether to set or merely warn about permission changes
-(\fICHECK_PERMISSIONS\fR). In system mode non-option arguments refer
-to files. Ie just as if the \-\-examine option was specified for them.
-.TP
-.IR \-\-set
-Actually apply the file permissions. The default is to check and
-warn only unless in system mode where \fICHECK_PERMISSIONS\fR
-specifies the default behavior.
-.TP
-.IR \-\-warn
-Opposite of --set, ie warn only but don't make actual changes
-.TP
-.IR \-\-noheader
-Omit printing the output header lines.
-.TP
-.IR \-\-fscaps,\ \-\-no\-fscaps
-Enable or disable use of fscaps. In system mode the setting of
-\fIPERMISSIONS_FSCAPS\fR determines whether fscaps are on or off when this
-option is not set.
-.TP
-.IR \-\-examine\ file
-Check permissions for this file instead of all files listed in the permissions files.
-.TP
-.IR \-\-files\ filelist
+\fB\-\-set\fR
+.RS 4
+Actually apply the file permissions\&. The default is to check and warn only, unless in system mode where
+\fICHECK_PERMISSIONS\fR
+specifies the default behavior\&.
+.RE
+.PP
+\fB\-\-warn\fR
+.RS 4
+Opposite of \-\-set, i\&.e\&. warn only but don\(cqt make actual changes
+.RE
+.PP
+\fB\-\-noheader\fR
+.RS 4
+Omit printing the output header lines\&.
+.RE
+.PP
+\fB\-\-fscaps, \-\-no\-fscaps\fR
+.RS 4
+Enable or disable use of fscaps\&. In system mode the setting of
+\fIPERMISSIONS_FSCAPS\fR
+determines whether fscaps are on or off when this option is not set\&.
+.RE
+.PP
+\fB\-\-examine <file>\fR
+.RS 4
+Check permissions for this file instead of all files listed in the permissions files\&.
+.RE
+.PP
+\fB\-\-files <filelist\&...>\fR
+.RS 4
 Check permissions for the files listed in
-.IR filelist
-and instead of all files listed in the permissions files.
-.TP
-.IR \-\-root\ directory
-Check files relative to the specified directory.
+\fIfilelist\fR
+instead of all files listed in the permissions files\&.
+.RE
 .PP
+\fB\-\-root <directory>\fR
+.RS 4
+Check files relative to the specified directory\&.
+.RE
 .SH "ENVIRONMENT VARIABLES"
-.B PERMCTL_ALLOW_INSECURE_MODE_IF_NO_PROC
-Allow to operate without mounted /proc filesystem. This is an unsafe mode that must only
-be used in controlled environments where unprivileged users can't influence filesystem
-operation.
 .PP
-.SH EXAMPLES
-.PP
-.B permctl --set /usr/share/permissions/permissions /usr/share/permissions/permissions.secure
-.PP
-parses the files /usr/share/permissions/permissions and
-/usr/share/permissions/permissions and sets the
-access mode and the user- and group memberships for each file listed.
-.PP
-.B permctl --system /bin/ping
-.PP
-Run in system mode and only correct permissions of /bin/ping
-.
+\fBPERMCTL_ALLOW_INSECURE_MODE_IF_NO_PROC\fR
+.RS 4
+Allow to operate without mounted /proc filesystem\&. This is an unsafe mode that must only be used in controlled environments where unprivileged users can\(cqt influence filesystem operation\&.
+.RE
+.SH "EXAMPLES"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+permctl \-\-set /usr/share/permissions/permissions /usr/share/permissions/permissions\&.secure
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Parses the files /usr/share/permissions/permissions and /usr/share/permissions/permissions and sets the access mode and the user\- and group memberships for each file listed\&.
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+permctl \-\-system /bin/ping
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Run in system mode and only correct permissions of /bin/ping\&.
 .SH "SEE ALSO"
 .sp
 permissions(5)
-.
-.SH COPYRIGHT
-1996-2003 SuSE Linux AG, Nuernberg, Germany.
-
-2008-2019 SUSE LINUX Products GmbH
-
-2019-2024 SUSE Software Solutions Germany GmbH
-.SH AUTHORS
+.SH "COPYRIGHT"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+1996\-2003 SuSE Linux AG, Nuernberg, Germany\&.
+2008\-2019 SUSE LINUX Products GmbH
+2019\-2024 SUSE Software Solutions Germany GmbH
+.fi
+.if n \{\
+.RE
+.\}
+.SH "AUTHORS"
+.sp
 Reinhold Sojer, Ruediger Oertel, Michael Schroeder, Ludwig Nussel
-.PP
+.sp
 Useful changes and additions by Tobias Burnus
-.PP
+.sp
 Major refactoring by Matthias Gerstner, Malte Kraus

--- a/man/permctl.adoc
+++ b/man/permctl.adoc
@@ -1,0 +1,101 @@
+PERMCTL(8)
+==========
+
+NAME
+----
+
+permctl - tool to check and set file permissions
+
+SYNOPSIS
+--------
+
+*permctl* [OPTIONS] <permission-files...>
+
+*permctl* --system [OPTIONS] <files...>
+
+DESCRIPTION
+-----------
+
+The program __/usr/bin/permctl__ is a tool to check and set file permissions. It
+was previously called chkstat, but has been renamed to better describe its
+purpose.
+
+permctl can either operate in system mode or on individually specified
+permission files. In system mode, __/etc/sysconfig/security__ determines
+which level to use and whether to actually apply permission changes.
+
+OPTIONS
+-------
+
+*--system*::
+  Run in system mode. Parses __/etc/sysconfig/security__ to
+  determine which security level to use (_PERMISSION_SECURITY_)
+  and whether to set or merely warn about permission changes
+  (_CHECK_PERMISSIONS_). In system mode non-option arguments refer
+  to files. I.e. just as if the --examine option was specified for them.
+*--set*::
+  Actually apply the file permissions. The default is to check and
+  warn only, unless in system mode where _CHECK_PERMISSIONS_
+  specifies the default behavior.
+*--warn*::
+  Opposite of --set, i.e. warn only but don't make actual changes
+*--noheader*::
+  Omit printing the output header lines.
+*--fscaps, --no-fscaps*::
+  Enable or disable use of fscaps. In system mode the setting of
+  _PERMISSIONS_FSCAPS_ determines whether fscaps are on or off when this
+  option is not set.
+*--examine <file>*::
+  Check permissions for this file instead of all files listed in the
+  permissions files.
+*--files <filelist...>*::
+  Check permissions for the files listed in _filelist_ instead of all files
+  listed in the permissions files.
+*--root <directory>*::
+  Check files relative to the specified directory.
+
+ENVIRONMENT VARIABLES
+---------------------
+
+*PERMCTL_ALLOW_INSECURE_MODE_IF_NO_PROC*::
+  Allow to operate without mounted /proc filesystem. This is an unsafe mode
+  that must only be used in controlled environments where unprivileged users
+  can't influence filesystem operation.
+
+EXAMPLES
+--------
+
+----
+permctl --set /usr/share/permissions/permissions /usr/share/permissions/permissions.secure
+----
+
+Parses the files /usr/share/permissions/permissions and
+/usr/share/permissions/permissions and sets the
+access mode and the user- and group memberships for each file listed.
+
+----
+permctl --system /bin/ping
+----
+
+Run in system mode and only correct permissions of /bin/ping.
+
+SEE ALSO
+--------
+
+permissions(5)
+
+COPYRIGHT
+---------
+
+ 1996-2003 SuSE Linux AG, Nuernberg, Germany.
+ 2008-2019 SUSE LINUX Products GmbH
+ 2019-2024 SUSE Software Solutions Germany GmbH
+
+AUTHORS
+-------
+
+Reinhold Sojer, Ruediger Oertel, Michael Schroeder, Ludwig Nussel
+
+Useful changes and additions by Tobias Burnus
+
+Major refactoring by Matthias Gerstner, Malte Kraus

--- a/man/permissions.5
+++ b/man/permissions.5
@@ -1,115 +1,200 @@
-.TH "PERMISSIONS" "5" "07/11/2010" "" ""
+'\" t
+.\"     Title: permissions
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 04/24/2024
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "PERMISSIONS" "5" "04/24/2024" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
 .\" disable hyphenation
 .nh
 .\" disable justification (adjust text to left margin only)
-.ad b
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
 .SH "NAME"
-permission - default permission settings
+permissions \- default permission settings
 .SH "SYNOPSIS"
-The permctl program sets permissions and ownerships according to the
-permission files\.
+.sp
+The permctl program sets permissions and ownerships of files according to the permission configuration files\&.
 .SH "DESCRIPTION"
-.PP
-\- The files /usr/share/permissions/permissions\.* are line based and space delimited\.
-.br
-\- Lines starting with '#' are comments\.
-.br
-\- The first column specifies the file name\. Directory names have to
-end with a slash\.
-.br
-\- The second column specifies the owner and group\.
-.br
-\- The third column specifies the file mode\.
-.br
-\- The special value \fB+capabilities\fR in the first column extends
-the information of the previous line with file capabilites.
-.PP
-The file name in the first column can contain contain variables as defined in
-the \fIvariables.conf\fR file.
-.br
-A variable expands to one or more alternative path segments that relate to the
-same program or file. permctl will look in each possible path
-resulting from the variable expansion and apply the permissions accordingly.
-.PP
-The variables.conf file will ignore empty lines, whitespace only lines or
-comment lines starting with '#'. All other lines must contain variable
-definitions that follow the syntax \fBmyvar = /path/1 /path/2\fR.  This
-example will declare a variable identified as \fImyvar\fR that will expand to
-both specified path segments.
-.br
-Path segments appearing in variable assignments need to be separated by
-whitespace characters. The path values cannot contain whitespace themselves.
-The variable identifier is limited to alphanumeric characters and the
-underscore '_' character.
-.PP
-To reference a variable in a permissions file it needs to be dereferenced
-using the \fB%{myvar}\fR syntax. The variable needs to appear as a single path
-component and cannot be mixed with other literal characters. Multiple
-variables per path are allowed. The following are valid variable uses:
-.PP
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+The files /usr/share/permissions/permissions\&.* are line based and space delimited\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Lines starting with
+\*(Aq#\*(Aq
+are comments\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+The first column specifies the file name\&. Directory names have to end with a slash\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+The second column specifies the owner and group\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+The third column specifies the file mode\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+The special value
+\fB+capabilities\fR
+in the first column extends the information of the previous line with file capabilites\&.
+.RE
+.sp
+The file name in the first column can contain contain variables as defined in the \fIvariables\&.conf\fR file\&. A variable expands to one or more alternative path segments that relate to the same program or file\&. permctl will look in each possible path resulting from the variable expansion and apply the permissions accordingly\&.
+.sp
+The variables\&.conf file will ignore empty lines, whitespace only lines or comment lines starting with \fI#\fR\&. All other lines must contain variable definitions that follow the syntax \fBmyvar = /path/1 /path/2\fR\&. This example will declare a variable identified as myvar that will expand to both specified path segments\&.
+.sp
+Path segments appearing in variable assignments need to be separated by whitespace characters\&. The path values cannot contain whitespace themselves\&. The variable identifier is limited to alphanumeric characters and the underscore character\&.
+.sp
+To reference a variable in a permissions file it needs to be dereferenced using the %{myvar} syntax\&. The variable needs to appear as a single path component and cannot be mixed with other literal characters\&. Multiple variables per path are allowed\&. The following are valid variable uses:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
 \- %{myvar}/sub/path
-.br
 \- /parent/path/%{myvar}
-.br
 \- /parent/path/%{myvar}/sub/path
-.br
 \- %{var1}/path/%{var2}
-.PP
+.fi
+.if n \{\
+.RE
+.\}
+.sp
 While the following are invalid:
-.PP
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
 \- /prefix/pre%{myvar}suf/suffix
-.br
 \- /%{var}text/path
-.br
 \- /path/text%{var}
+.fi
+.if n \{\
+.RE
+.\}
 .SH "EXAMPLES"
-.PP
+.sp
 A specification like this:
-.PP
-\&# in variables.conf
-.br
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# in variables\&.conf
 lib_dirs = /lib /lib64
-.br
 sub_dirs = prog_v1 prog_v2
-.PP
-\&# in a permissions profile
-.br
-%{lib_dirs}/%{sub_dirs}/libsomething.so root:root 04755
-.PP
-Will cause permctl to try and apply the given permission to all of the
-following paths:
-.PP
-\- /lib/prog_v1/libsomething.so
-.br
-\- /lib64/prog_v1/libsomething.so
-.br
-\- /lib/prog_v2/libsomething.so
-.br
-\- /lib64/prog_v2/libsomething.so
+
+# in a permissions profile
+%{lib_dirs}/%{sub_dirs}/libsomething\&.so root:root 04755
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Will cause permctl to try and apply the given permission to all of the following paths:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+/lib/prog_v1/libsomething\&.so
+/lib64/prog_v1/libsomething\&.so
+/lib/prog_v2/libsomething\&.so
+/lib64/prog_v2/libsomething\&.so
+.fi
+.if n \{\
+.RE
+.\}
 .SH "FILES"
 .sp
+.if n \{\
+.RS 4
+.\}
+.nf
 /usr/share/permissions/permissions
-.br
-/usr/share/permissions/permissions\.easy
-.br
-/usr/share/permissions/permissions\.secure
-.br
-/usr/share/permissions/permissions\.paranoid
-.br
-.br
-/usr/share/permissions/packages\.d/*
-/usr/share/permissions/permissions\.d/* (deprecated)
-.br
-/usr/share/permissions/variables.conf
-.br
-/etc/permissions\.local
-.br
+/usr/share/permissions/permissions\&.easy
+/usr/share/permissions/permissions\&.secure
+/usr/share/permissions/permissions\&.paranoid
+/usr/share/permissions/packages\&.d/*
+/usr/share/permissions/permissions\&.d/* (deprecated)
+/usr/share/permissions/variables\&.conf
+/etc/permissions\&.local
+.fi
+.if n \{\
+.RE
+.\}
 .SH "SEE ALSO"
+.sp
 permctl(8)
+.SH "AUTHORS"
 .sp
-.SH "AUTHOR"
-Written by Ludwig Nussel
-.sp
+Written by Ludwig Nussel\&.
 .SH "REPORTING BUGS"
-Report bugs to https://bugzilla\.suse\.com/
 .sp
+Report bugs to https://bugzilla\&.suse\&.com/ or to https://github\&.com/openSUSE/permissions/\&.

--- a/man/permissions.adoc
+++ b/man/permissions.adoc
@@ -1,0 +1,108 @@
+PERMISSIONS(5)
+==============
+
+NAME
+----
+permissions - default permission settings
+
+SYNOPSIS
+--------
+The permctl program sets permissions and ownerships of files according to the
+permission configuration files.
+
+DESCRIPTION
+-----------
+
+- The files /usr/share/permissions/permissions.* are line based and space delimited.
+- Lines starting with `'#'` are comments.
+- The first column specifies the file name. Directory names have to end with a slash.
+- The second column specifies the owner and group.
+- The third column specifies the file mode.
+- The special value *+capabilities* in the first column extends the
+  information of the previous line with file capabilites.
+
+The file name in the first column can contain contain variables as defined in
+the __variables.conf__ file. A variable expands to one or more alternative path
+segments that relate to the same program or file. permctl will look in each
+possible path resulting from the variable expansion and apply the permissions
+accordingly.
+
+The variables.conf file will ignore empty lines, whitespace only lines or
+comment lines starting with '#'. All other lines must contain variable
+definitions that follow the syntax **myvar = /path/1 /path/2**.  This
+example will declare a variable identified as `myvar` that will expand to
+both specified path segments.
+
+Path segments appearing in variable assignments need to be separated by
+whitespace characters. The path values cannot contain whitespace themselves.
+The variable identifier is limited to alphanumeric characters and the
+underscore character.
+
+To reference a variable in a permissions file it needs to be dereferenced
+using the `%{myvar}` syntax. The variable needs to appear as a single path
+component and cannot be mixed with other literal characters. Multiple
+variables per path are allowed. The following are valid variable uses:
+
+----
+- %{myvar}/sub/path
+- /parent/path/%{myvar}
+- /parent/path/%{myvar}/sub/path
+- %{var1}/path/%{var2}
+----
+
+While the following are invalid:
+
+----
+- /prefix/pre%{myvar}suf/suffix
+- /%{var}text/path
+- /path/text%{var}
+----
+
+EXAMPLES
+--------
+
+A specification like this:
+
+----
+# in variables.conf
+lib_dirs = /lib /lib64
+sub_dirs = prog_v1 prog_v2
+
+# in a permissions profile
+%{lib_dirs}/%{sub_dirs}/libsomething.so root:root 04755
+----
+
+Will cause permctl to try and apply the given permission to all of the
+following paths:
+
+ /lib/prog_v1/libsomething.so
+ /lib64/prog_v1/libsomething.so
+ /lib/prog_v2/libsomething.so
+ /lib64/prog_v2/libsomething.so
+
+FILES
+-----
+
+ /usr/share/permissions/permissions
+ /usr/share/permissions/permissions.easy
+ /usr/share/permissions/permissions.secure
+ /usr/share/permissions/permissions.paranoid
+ /usr/share/permissions/packages.d/*
+ /usr/share/permissions/permissions.d/* (deprecated)
+ /usr/share/permissions/variables.conf
+ /etc/permissions.local
+
+SEE ALSO
+--------
+
+permctl(8)
+
+AUTHORS
+-------
+
+Written by Ludwig Nussel.
+
+REPORTING BUGS
+--------------
+
+Report bugs to https://bugzilla.suse.com/ or to https://github.com/openSUSE/permissions/.

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,24 @@ executable('permctl', [
   install: true
 )
 
+a2x = find_program('a2x', required: false)
+
+if a2x.found()
+  man5 = custom_target('man_permissions',
+    output: 'permissions.5',
+    input: 'man/permissions.adoc',
+    command: [a2x, '-f', 'manpage', '@INPUT@'])
+
+  man8 = custom_target('man_permctl',
+    output: 'permctl.8',
+    input: 'man/permctl.adoc',
+    command: [a2x, '-f', 'manpage', '@INPUT@'])
+
+  alias_target('generate-man', man5, man8)
+else
+  message('No "a2x" program found. Install asciidoc for being able to generate man pages')
+endif
+
 # backward compatibility symlink
 install_symlink('chkstat', pointing_to: 'permctl', install_dir: 'bin')
 install_man('man/permctl.8')


### PR DESCRIPTION
To prevent eye cancer, use asciidoc to generate man pages from a simple markup language.

The presence of asciidoc is optional, to avoid the burden of installing third party tooling, even if man pages are not touched. Also this makes packaging simpler. The generated man pages are thus still checked-in.

This also means that developers that change the asciidoc sources need to explicitly run `meson compile generate-man` to update the man page output.