### PR TITLE
permctl: return special exit code in --warn mode if entries need fixing

### DIFF
--- a/man/permctl.8
+++ b/man/permctl.8
@@ -2,12 +2,12 @@
 .\"     Title: permctl
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/30/2024
+.\"      Date: 05/15/2024
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "PERMCTL" "8" "04/30/2024" "\ \&" "\ \&"
+.TH "PERMCTL" "8" "05/15/2024" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -94,6 +94,9 @@ Check files relative to the specified directory\&.
 .RS 4
 Allow to operate without mounted /proc file system\&. This is an unsafe mode that must only be used in controlled environments where unprivileged users can\(cqt influence file system operation\&.
 .RE
+.SH "EXIT STATUS"
+.sp
+permctl returns 1 if any fatal errors have been encountered that prevented it from determining or adjusting file permissions\&. It returns 2 if \fB\-\-warn\fR was given and one or more entries need fixing\&. In all other cases it returns 0\&.
 .SH "EXAMPLES"
 .sp
 .if n \{\

--- a/man/permctl.adoc
+++ b/man/permctl.adoc
@@ -66,6 +66,13 @@ ENVIRONMENT VARIABLES
   that must only be used in controlled environments where unprivileged users
   can't influence file system operation.
 
+EXIT STATUS
+-----------
+
+permctl returns 1 if any fatal errors have been encountered that prevented it
+from determining or adjusting file permissions. It returns 2 if *--warn* was
+given and one or more entries need fixing. In all other cases it returns 0.
+
 EXAMPLES
 --------
 

--- a/src/entryproc.h
+++ b/src/entryproc.h
@@ -14,6 +14,16 @@
  * would be performed. Or it can actually apply necessary changes.
  **/
 class EntryProcessor {
+public: // types
+
+    enum class Result {
+        ENTRY_GOOD,    ///< The entry was validated and file status is good.
+        ENTRY_BAD,     ///< The entry would need fixing but apply_changes is not set.
+        ENTRY_FIXED,   ///< The entry needed fixing and has been fixed.
+        ENTRY_SKIPPED, ///< The entry was skipped, because the file is not present or otherwise checking it was not possible.
+        FAILED         ///< a fatal error condition was encountered, entry status is unknown.
+    };
+
 public: // functions
 
     EntryProcessor(const ProfileEntry &entry, const CmdlineArgs &args, const bool apply_changes);
@@ -28,7 +38,7 @@ public: // functions
      * \param[in] have_proc Whether a /proc mount is available. If not then
      * no changes will be applied in the file system for security reasons.
      **/
-    bool process(const bool have_proc);
+    Result process(const bool have_proc);
 
 protected: // types
 


### PR DESCRIPTION
To make `--warn` mode more useful, return a special exit status in case entries have been found in need of fixing.

Closes #191.