### PR TITLE
cockpit: moved setuid executable (bsc#1228548)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -480,8 +480,8 @@
 /usr/lib/enlightenment/utils/enlightenment_system       root:root  4755
 /usr/lib64/enlightenment/utils/enlightenment_system     root:root  4755
 
-# setuid bit for cockpit (bsc#1169614)
-/usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+# setuid bit for cockpit (bsc#1169614 bsc#1228548)
+/usr/lib/cockpit/cockpit-session                        root:cockpit-wsinstance  4750
 
 # ksysguard network helper (bsc#1151190)
 /usr/lib/libexec/ksysguard/ksgrd_network_helper             root:root       0755

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -483,8 +483,8 @@
 /usr/lib/enlightenment/utils/enlightenment_system       root:root  0755
 /usr/lib64/enlightenment/utils/enlightenment_system     root:root  0755
 
-# setuid bit for cockpit (bsc#1169614)
-/usr/lib/cockpit-session                                root:cockpit-wsinstance  0750
+# setuid bit for cockpit (bsc#1169614 bsc#1228548)
+/usr/lib/cockpit/cockpit-session                        root:cockpit-wsinstance  0750
 
 # ksysguard network helper (bsc#1151190)
 /usr/lib/libexec/ksysguard/ksgrd_network_helper             root:root       0755

--- a/permissions.secure
+++ b/permissions.secure
@@ -516,8 +516,8 @@
 /usr/lib/enlightenment/utils/enlightenment_system       root:root  4755
 /usr/lib64/enlightenment/utils/enlightenment_system     root:root  4755
 
-# setuid bit for cockpit (bsc#1169614)
-/usr/lib/cockpit-session                                root:cockpit-wsinstance  4750
+# setuid bit for cockpit (bsc#1169614 bsc#1228548)
+/usr/lib/cockpit/cockpit-session                        root:cockpit-wsinstance  4750
 
 # ksysguard network helper (bsc#1151190)
 /usr/lib/libexec/ksysguard/ksgrd_network_helper             root:root       0755


### PR DESCRIPTION
`/usr/lib/cockpit-session` moved to
`/usr/lib/cockpit/cockpit-session`

No other changes.