### PR TITLE
chkstat: backport support to operate in insecure mode via envvar opt-…

### DIFF
--- a/chkstat.8
+++ b/chkstat.8
@@ -67,6 +67,14 @@ and instead of all files listed in the permissions files.
 .IR \-\-root\ directory
 Check files relative to the specified directory.
 .PP
+.SH ENVIRONMENT VARIABLES
+.PP
+\fBCHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC\fR
+.RS 4
+Allow to operate without mounted /proc file system. This is an
+unsafe mode that must only be used in controlled environments where
+unprivileged users can’t influence file system operation.
+.RE
 .SH EXAMPLES
 .PP
 .B chkstat --set /etc/permissions /etc/permissions.secure


### PR DESCRIPTION
…in (bsc#1219736)

This is a manual backport of master branch commit 9cea63d3f. This change adds support to ignore a missing /proc file system, if the environment variable CHKSTAT_ALLOW_INSECURE_MODE_IF_NO_PROC is set when invoking `chkstat`. Some container builds don't have /proc available and thus have issues with chkstat's behaviour.

Since `chkstat` cannot determine on its own whether it is running in a special situation (build environment) or in a live system, the administrators need to provide this information via the environment variable.