### PR TITLE
permissions: reintroduce nscd socket, which acts as a whitelisting fo…

### DIFF
--- a/permissions
+++ b/permissions
@@ -40,6 +40,8 @@
 
 /var/spool/uucp/                                        uucp:uucp          755
 /var/yp/                                                root:root          755
+/var/run/nscd/socket                                    root:root          666
+/run/nscd/socket                                        root:root          666
 
 #
 # /etc


### PR DESCRIPTION
…r glibc (bsc#1236960)

The cherry-pick of cleanup commits we did for SLE-15-SP6 went a bit too far. This entry is still needed and acts as a whitelisting for glibc on SLE.