### PR TITLE
nvidia-modprobe: SLE-15-SP4 backport (bsc#1246776)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -491,3 +491,6 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 2755
+
+# nvidia-modprobe (bsc#1230950 bsc#1246776)
+/usr/bin/nvidia-modprobe                                root:root 4755

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -492,3 +492,6 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 0755
+
+# nvidia-modprobe (bsc#1230950 bsc#1246776)
+/usr/bin/nvidia-modprobe                                root:root 0755

--- a/permissions.secure
+++ b/permissions.secure
@@ -527,3 +527,6 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 2755
+
+# nvidia-modprobe (bsc#1230950 bsc#1246776)
+/usr/bin/nvidia-modprobe                                root:root 4755


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1246776

previously reviewed in: 
https://bugzilla.suse.com/show_bug.cgi?id=1230950