### PR TITLE
profiles: drop shadow related entries (bsc#1254844)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -35,11 +35,6 @@
 /usr/bin/crontab                                        root:trusted      4755
 /usr/bin/gpasswd                                        root:shadow       4755
 /usr/bin/newgrp                                         root:root         4755
-/usr/bin/passwd                                         root:shadow       4755
-/usr/bin/chfn                                           root:shadow       4755
-/usr/bin/chage                                          root:shadow       2755
-/usr/bin/chsh                                           root:shadow       4755
-/usr/bin/expiry                                         root:shadow       4755
 /usr/bin/sudo                                           root:root         4755
 /usr/sbin/su-wrapper                                    root:root         4755
 # #331020
@@ -220,12 +215,6 @@
 # suexec2 is a symlink for now, leave as-is
 #
 /usr/sbin/suexec            				root:root       0755
-
-# newgidmap / newuidmap (bsc#979282, bsc#1048645, bsc#1208309)
-/usr/bin/newgidmap					root:root	0755
- +capabilities cap_setgid=ep
-/usr/bin/newuidmap					root:root	0755
- +capabilities cap_setuid=ep
 
 # kwayland (bsc#1062182)
 /usr/bin/kwin_wayland					root:root	0755

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -53,11 +53,6 @@
 /usr/bin/crontab                                        root:trusted      0755
 /usr/bin/gpasswd                                        root:shadow       0755
 /usr/bin/newgrp                                         root:root         0755
-/usr/bin/passwd                                         root:shadow       0755
-/usr/bin/chfn                                           root:shadow       0755
-/usr/bin/chage                                          root:shadow       0755
-/usr/bin/chsh                                           root:shadow       0755
-/usr/bin/expiry                                         root:shadow       0755
 /usr/bin/sudo                                           root:root         0755
 /usr/sbin/su-wrapper                                    root:root         0755
 # #331020
@@ -232,10 +227,6 @@
 # suexec2 is a symlink for now, leave as-is
 #
 /usr/sbin/suexec            				root:root       0755
-
-# newgidmap / newuidmap (bsc#979282, bsc#1048645, bsc#1208309)
-/usr/bin/newgidmap					root:root	0755
-/usr/bin/newuidmap					root:root	0755
 
 # kwayland (bsc#1062182)
 /usr/bin/kwin_wayland					root:root	0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -77,11 +77,6 @@
 /usr/bin/crontab                                        root:trusted      4750
 /usr/bin/gpasswd                                        root:shadow       4755
 /usr/bin/newgrp                                         root:root         4755
-/usr/bin/passwd                                         root:shadow       4755
-/usr/bin/chfn                                           root:shadow       4755
-/usr/bin/chage                                          root:shadow       2755
-/usr/bin/chsh                                           root:shadow       4755
-/usr/bin/expiry                                         root:shadow       4755
 /usr/bin/sudo                                           root:root         4755
 /usr/sbin/su-wrapper                                    root:root         0755
 # #331020
@@ -260,12 +255,6 @@
 # suexec2 is a symlink for now, leave as-is
 #
 /usr/sbin/suexec             				root:root       0755
-
-# newgidmap / newuidmap (bsc#979282, bsc#1048645, bsc#1208309)
-/usr/bin/newgidmap					root:root	0755
- +capabilities cap_setgid=ep
-/usr/bin/newuidmap					root:root	0755
- +capabilities cap_setuid=ep
 
 # kwayland (bsc#1062182)
 /usr/bin/kwin_wayland					root:root	0755


### PR DESCRIPTION
These entries are now managed by a permissions.d drop-in configuration file part of shadow-pw-mgmt. This is to allow for better support of setuid-less systems, where these account management features are provided by account-utils.