### PR TITLE
Support Coupling of permissions Entries to Package Names

### DIFF
--- a/etc/permissions
+++ b/etc/permissions
@@ -3,34 +3,15 @@
 # Maintainer: SUSE security team <security@suse.de>
 #
 # This file is used by permctl (and indirectly by various RPM scripts)
-# to check or set the modes and ownerships of files and directories in the installation.
+# to check or set the modes and ownerships of files and directories in the
+# installation.
 #
-# There is a set of files with similar meaning in a SUSE installation:
-# /usr/share/permissions/permissions  (This file)
-# /usr/share/permissions/permissions.easy
-# /usr/share/permissions/permissions.secure
-# /usr/share/permissions/permissions.paranoid
-# /etc/permissions.local
-# Please see the respective files for their meaning.
+# See "man permissions(5)" for more information on permissions configuration
+# files.
 #
-#
-# Format:
-# <file> <owner>:<group> <permission>
-#
-# How it works:
-# To change an entry, copy the line to permissions.local, modify it
-# to suit your needs and call "permctl --system"
-#
-# permctl uses the variable PERMISSION_SECURITY from
-# /etc/sysconfig/security to determine which security level to
-# apply.
-# In addition to the central files listed above the directory
-# /usr/share/permissions/permissions.d/ (deprecated) and
-# /usr/share/permissions/packages.d/ can contain permission files
-# that belong to the packages they modify file modes for. These
-# permission files are to switch between conflicting file modes of
-# the same file paths in different packages (popular example:
-# sendmail and postfix, path /usr/sbin/sendmail).
+# To modify a permission entry, copy the respective line to
+# /etc/permissions.local, modify it to suit your needs and call `permctl
+# --system` to adjust the files on disk.
 
 # utempter
 /usr/libexec/utempter/utempter                          root:utmp         2755

--- a/etc/permissions
+++ b/etc/permissions
@@ -1,9 +1,6 @@
-# /usr/share/permissions/permissions
+# Copyright (c) 2026 SUSE Software Solutions Germany GmbH
 #
-# Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.
-# Copyright (c) 2011 SUSE Linux Products GmbH Nuernberg, Germany.
-#
-# Author: Roman Drahtmueller <draht@suse.de>, 2001
+# Maintainer: SUSE security team <security@suse.de>
 #
 # This file is used by permctl (and indirectly by various RPM scripts)
 # to check or set the modes and ownerships of files and directories in the installation.

--- a/man/permctl.8
+++ b/man/permctl.8
@@ -2,12 +2,12 @@
 .\"     Title: permctl
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/22/2024
+.\"      Date: 01/02/2026
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "PERMCTL" "8" "05/22/2024" "\ \&" "\ \&"
+.TH "PERMCTL" "8" "01/02/2026" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-permctl \- tool to check and set system wide file permissions
+permctl \- tool to check and set system\-wide file permissions
 .SH "SYNOPSIS"
 .sp
 \fBpermctl\fR [OPTIONS] <permission\-files\&...>
@@ -38,7 +38,9 @@ permctl \- tool to check and set system wide file permissions
 .sp
 The program \fI/usr/bin/permctl\fR is a tool to check and set file permissions\&. It was previously called chkstat, but has been renamed to better describe its purpose\&.
 .sp
-permctl can either operate in system mode or on individually specified permission files\&. In system mode, the file \fI/etc/sysconfig/security\fR determines which profile to use and whether to actually apply permission changes\&.
+permctl can either operate in system mode or on individually specified permissions(5) files\&. In system mode, the file \fI/etc/sysconfig/security\fR determines which profile to use and whether to actually apply permission changes\&. When explicit file paths are specified in system mode, then only the permissions of the given paths will be checked and adjusted\&. If no paths are specified then all paths listed in the configured permissions profiles will be processed\&.
+.sp
+The main purpose of permctl is to manage security\-sensitive file permissions like setuid\-root bits, capability bits or access control lists (ACL) in the system\&. The permissions configuration files allow to adjust these file permissions to match the user\(cqs needs\&. The system\-wide permissions profiles also act as a gatekeeping mechanism in SUSE distributions\&. Packages may not install security\-sensitive programs (which e\&.g\&. carry a setuid\-root bit) when they are not listed in the permissions profiles\&.
 .SH "OPTIONS"
 .PP
 \fB\-\-system\fR
@@ -62,7 +64,8 @@ Opposite of \-\-set, i\&.e\&. warn only, but don\(cqt make actual changes\&.
 .PP
 \fB\-\-noheader\fR
 .RS 4
-Omit printing the output header lines which describe the configuration files used by permctl\&.
+Omit printing the output header lines which describe the configuration files used by
+permctl\&.
 .RE
 .PP
 \fB\-\-fscaps, \-\-no\-fscaps\fR
@@ -87,6 +90,18 @@ instead of all files listed in the permissions files\&. Can appear multiple time
 \fB\-\-root <directory>\fR
 .RS 4
 Check files relative to the specified directory\&.
+.RE
+.PP
+\fB\-\-config\-root <dir>\fR
+.RS 4
+Lookup configuration files relative to the given root directory\&. This is only intended for testing purposes\&.
+.RE
+.PP
+\fB\-\-level "level1 [level2\&...]"\fR
+.RS 4
+Force the application of the given security level(s) e\&.g\&. "local paranoid" would apply the local and paranoid permission profiles\&. This overrides the settings found in
+\fI/etc/sysconfig/security\fR
+(only supported in \-\-system mode)\&.
 .RE
 .SH "ENVIRONMENT VARIABLES"
 .PP
@@ -133,7 +148,7 @@ permissions(5)
 .nf
 1996\-2003 SuSE Linux AG, Nuernberg, Germany\&.
 2008\-2019 SUSE LINUX Products GmbH
-2019\-2024 SUSE Software Solutions Germany GmbH
+2019\-2026 SUSE Software Solutions Germany GmbH
 .fi
 .if n \{\
 .RE

--- a/man/permctl.adoc
+++ b/man/permctl.adoc
@@ -4,7 +4,7 @@ PERMCTL(8)
 NAME
 ----
 
-permctl - tool to check and set system wide file permissions
+permctl - tool to check and set system-wide file permissions
 
 SYNOPSIS
 --------
@@ -16,14 +16,25 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The program __/usr/bin/permctl__ is a tool to check and set file permissions. It
-was previously called `chkstat`, but has been renamed to better describe its
-purpose.
+The program __/usr/bin/permctl__ is a tool to check and set file permissions.
+It was previously called `chkstat`, but has been renamed to better describe
+its purpose.
 
-permctl can either operate in system mode or on individually specified
-permission files. In system mode, the file __/etc/sysconfig/security__
+`permctl` can either operate in system mode or on individually specified
+`permissions(5)` files. In system mode, the file __/etc/sysconfig/security__
 determines which profile to use and whether to actually apply permission
-changes.
+changes. When explicit file paths are specified in system mode, then only the
+permissions of the given paths will be checked and adjusted. If no paths are
+specified then all paths listed in the configured permissions profiles will be
+processed.
+
+The main purpose of `permctl` is to manage security-sensitive file permissions
+like setuid-root bits, capability bits or access control lists (ACL) in the
+system. The `permissions` configuration files allow to adjust these file
+permissions to match the user's needs. The system-wide `permissions` profiles
+also act as a gatekeeping mechanism in SUSE distributions. Packages may not
+install security-sensitive programs (which e.g. carry a setuid-root bit) when
+they are not listed in the permissions profiles.
 
 OPTIONS
 -------
@@ -43,7 +54,7 @@ OPTIONS
   Opposite of --set, i.e. warn only, but don't make actual changes.
 *--noheader*::
   Omit printing the output header lines which describe the configuration files
-  used by permctl.
+  used by `permctl`.
 *--fscaps, --no-fscaps*::
   Enable or disable use of file based capabilities. In system mode the setting of
   _PERMISSIONS_FSCAPS_ determines whether capabilities are applied, when this
@@ -57,6 +68,14 @@ OPTIONS
   contain the file paths to check, one per line.
 *--root <directory>*::
   Check files relative to the specified directory.
+*--config-root <dir>*::
+  Lookup configuration files relative to the given root directory. This is
+  only intended for testing purposes.
+*--level "level1 [level2...]"*::
+  Force the application of the given security level(s) e.g. "local paranoid"
+  would apply the local and paranoid permission profiles. This overrides the
+  settings found in __/etc/sysconfig/security__ (only supported in --system
+  mode).
 
 ENVIRONMENT VARIABLES
 ---------------------
@@ -69,9 +88,10 @@ ENVIRONMENT VARIABLES
 EXIT STATUS
 -----------
 
-permctl returns 1 if any fatal errors have been encountered that prevented it
-from determining or adjusting file permissions. It returns 2 if *--warn* was
-given and one or more entries need fixing. In all other cases it returns 0.
+`permctl` returns 1 if any fatal errors have been encountered that prevented
+it from determining or adjusting file permissions. It returns 2 if *--warn*
+was given and one or more entries need fixing. In all other cases it returns
+0.
 
 EXAMPLES
 --------
@@ -99,7 +119,7 @@ COPYRIGHT
 
  1996-2003 SuSE Linux AG, Nuernberg, Germany.
  2008-2019 SUSE LINUX Products GmbH
- 2019-2024 SUSE Software Solutions Germany GmbH
+ 2019-2026 SUSE Software Solutions Germany GmbH
 
 AUTHORS
 -------

--- a/man/permissions.5
+++ b/man/permissions.5
@@ -2,12 +2,12 @@
 .\"     Title: permissions
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/22/2024
+.\"      Date: 01/02/2026
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "PERMISSIONS" "5" "05/22/2024" "\ \&" "\ \&"
+.TH "PERMISSIONS" "5" "01/02/2026" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -35,12 +35,13 @@ The permctl(8) program sets permissions and ownerships of files according to the
 .SH "DESCRIPTION"
 .SS "File Format"
 .sp
-The files /usr/share/permissions/permissions\&.* are line based and space delimited\&. Lines starting with \*(Aq#\*(Aq are comments\&. A file entry consists of a line of the format
+The files /usr/share/permissions/permissions\&.* are line based and whitespace delimited\&. Lines starting with \*(Aq#\*(Aq are comments\&. A permissions entry consists of lines of the following format:
 .sp
 .if n \{\
 .RS 4
 .\}
 .nf
+:package: pkg1[,pkg2\&.\&.\&.]
 /path/to/file user:group 0755
  +capabilities cap_net_admin=ep
  +acl user:somebody:rwx
@@ -49,6 +50,8 @@ The files /usr/share/permissions/permissions\&.* are line based and space delimi
 .RE
 .\}
 .sp
+The main part of an entry is the file path specification as seen in the second line, which consists of three whitespace separated columns:
+.sp
 .RS 4
 .ie n \{\
 \h'-04'\(bu\h'+03'\c
@@ -57,7 +60,7 @@ The files /usr/share/permissions/permissions\&.* are line based and space delimi
 .sp -1
 .IP \(bu 2.3
 .\}
-The first column specifies the file name\&. Directory names must end with a slash\&.
+The first column specifies the file path\&. Directory paths must end with a slash\&.
 .RE
 .sp
 .RS 4
@@ -68,7 +71,7 @@ The first column specifies the file name\&. Directory names must end with a slas
 .sp -1
 .IP \(bu 2.3
 .\}
-The second column specifies the file owner and group delimited by a
+The second column specifies the designated file owner and group delimited by a
 \*(Aq:\*(Aq
 character\&.
 .RE
@@ -81,7 +84,7 @@ character\&.
 .sp -1
 .IP \(bu 2.3
 .\}
-The third column specifies the file mode in octal\&.
+The third column specifies the designated file mode in octal\&.
 .RE
 .sp
 Basic file entries can be extended by immediately following lines starting with +<keyword>\&. The following keywords are supported:
@@ -96,13 +99,16 @@ grant Linux capabilities to the file\&. The string specified here must conform t
 .RS 4
 grant additional access control list (ACL) entries to the file\&. The string specified here must conform to the rules found in
 \fIacl(5)\fR
-(section ACL TEXT FORMS)\&. The ACL entries will be merged with the basic octal file mode, therefore they must not contain any permissions for the file owner, group or other\&. If a file has extended ACL entries assigned, but none are configured in the permissions configuration, the extended ACL entries will be removed by
+(section ACL TEXT FORMS)\&. The ACL entries will be merged with the basic octal file mode, therefore they must not contain any permissions for the file owner, group or other\&. If a file has extended ACL entries assigned on disk, but none are configured in the permissions configuration, the extended ACL entries will be removed by
 permctl(8)\&.
 .RE
 .sp
-The file name in the first column of the base entry can contain contain variables as defined in the \fIvariables\&.conf\fR file\&. A variable expands to one or more alternative path segments that relate to the same program or file\&. permctl will look in each possible path resulting from the variable expansion and apply the permissions accordingly\&.
+The optional :package: directive allows to restrict following path entries to files owned by the given comma separated list of packages\&. The designated permissions will then only be assigned to the target file if it is owned by one of the specified packages according to the RPM system database\&. This setting is in effect for all subsequent permission entries in the file until another :package: directive is encountered\&. Entries appearing before any :package: line will always be applied without inspecting target file package ownership\&.
 .sp
-The variables\&.conf file will ignore empty lines, whitespace only lines or comment lines starting with \*(Aq#\*(Aq\&. All other lines must contain variable definitions that follow the syntax \fBmyvar = /path/1 /path/2\fR\&. This example will declare a variable identified as myvar that will expand to both specified path segments\&.
+The file name in the first column of the base entry can contain contain variables as defined in the \fIvariables\&.conf\fR file\&. A variable expands to one or more alternative path segments that relate to the same program or file\&. permctl will look in each possible path resulting from the variable expansion and apply the permissions accordingly\&.
+.SS "Path Variable Expansion via variables\&.conf"
+.sp
+The \fIvariables\&.conf\fR file will ignore empty lines, whitespace only lines or comment lines starting with \*(Aq#\*(Aq\&. All other lines must contain variable definitions that follow the syntax \*(Aqmyvar = /path/1 /path/2\*(Aq\&. This example will declare a variable identified as myvar that will expand to both specified path segments\&.
 .sp
 Path segments appearing in variable assignments need to be separated by whitespace characters\&. The path values cannot contain whitespace themselves\&. The variable identifier is limited to alphanumeric characters and the underscore character\&.
 .sp
@@ -135,6 +141,11 @@ While the following are invalid:
 .RE
 .\}
 .SS "Configuration File Locations"
+.PP
+\fB/usr/share/permissions/variables\&.conf\fR
+.RS 4
+contains variable expansion definitions\&.
+.RE
 .sp
 The permctl program, when run in \-\-system mode, will assemble a set of configuration entries depending on the profiles configured in \fI/etc/sysconfig/security\fR\&. The order of files parsed (with increasing priority) is as follows:
 .PP
@@ -159,7 +170,7 @@ contains local per\-system extra entries or overrides managed by the system admi
 .RE
 .SS "Available Predefined Profiles"
 .sp
-The permissions package ships the following predefines profiles:
+The permissions package ships the following predefined profiles:
 .PP
 \fBeasy\fR
 .RS 4
@@ -212,6 +223,32 @@ This will cause `permctl `to try and apply the given permission to all of the fo
 /lib64/prog_v1/libsomething\&.so
 /lib/prog_v2/libsomething\&.so
 /lib64/prog_v2/libsomething\&.so
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+The following example shows the effect of the :package: directive:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# this entry will always be applied regardless of which package owns \*(Aqsome_program\*(Aq\&.
+/usr/bin/some_program root:root 04755
+
+:package: sudo
+# this entry will only be applied if /usr/bin/sudo is owned by the "sudo" package\&.
+/usr/bin/sudo root:root 04755
+
+# this entry would also be applied only if owned by the "sudo" package, since
+# no new ":package:" directive appeared\&.
+/usr/bin/another_program root:root 04755
+
+:package: su
+# with the new package directive this entry will only be applied if
+# /usr/bin/su is owned by the "su" package\&.
+/usr/bin/su root:root 04755
 .fi
 .if n \{\
 .RE

--- a/man/permissions.adoc
+++ b/man/permissions.adoc
@@ -15,19 +15,23 @@ DESCRIPTION
 
 === File Format
 
-The files /usr/share/permissions/permissions.* are line based and space
-delimited. Lines starting with `'#'` are comments. A file entry consists of a
-line of the format
+The files /usr/share/permissions/permissions.* are line based and whitespace
+delimited. Lines starting with `'#'` are comments. A permissions entry
+consists of lines of the following format:
 
 ----
+:package: pkg1[,pkg2...]
 /path/to/file user:group 0755
  +capabilities cap_net_admin=ep
  +acl user:somebody:rwx
 ----
 
-- The first column specifies the file name. Directory names must end with a slash.
-- The second column specifies the file owner and group delimited by a `':'` character.
-- The third column specifies the file mode in octal.
+The main part of an entry is the file path specification as seen in the second
+line, which consists of three whitespace separated columns:
+
+- The first column specifies the file path. Directory paths must end with a slash.
+- The second column specifies the designated file owner and group delimited by a `':'` character.
+- The third column specifies the designated file mode in octal.
 
 Basic file entries can be extended by immediately following lines starting
 with `+<keyword>`. The following keywords are supported:
@@ -38,21 +42,32 @@ with `+<keyword>`. The following keywords are supported:
   string specified here must conform to the rules found in __acl(5)__ (section
   ACL TEXT FORMS). The ACL entries will be merged with the basic octal file
   mode, therefore they must not contain any permissions for the file owner,
-  group or other. If a file has extended ACL entries assigned, but none are
-  configured in the permissions configuration, the extended ACL entries will
-  be removed by `permctl(8)`.
+  group or other. If a file has extended ACL entries assigned on disk, but
+  none are configured in the permissions configuration, the extended ACL entries
+  will be removed by `permctl(8)`.
+
+The optional `:package:` directive allows to restrict following path entries
+to files owned by the given comma-separated list of packages. The designated
+permissions will then only be assigned to the target file if it is owned by
+one of the specified packages according to the RPM system database. This
+setting is in effect for all subsequent permission entries in the file until
+another `:package:` directive is encountered. Entries appearing before any
+`:package:` line will always be applied without inspecting target file package
+ownership.
 
 The file name in the first column of the base entry can contain contain
 variables as defined in the __variables.conf__ file. A variable expands to one
 or more alternative path segments that relate to the same program or file.
-permctl will look in each possible path resulting from the variable expansion
+`permctl` will look in each possible path resulting from the variable expansion
 and apply the permissions accordingly.
 
-The variables.conf file will ignore empty lines, whitespace only lines or
+=== Path Variable Expansion via variables.conf
+
+The __variables.conf__ file will ignore empty lines, whitespace only lines or
 comment lines starting with `'#'`. All other lines must contain variable
-definitions that follow the syntax **myvar = /path/1 /path/2**. This
-example will declare a variable identified as `myvar` that will expand to
-both specified path segments.
+definitions that follow the syntax `'myvar = /path/1 /path/2'`. This example
+will declare a variable identified as `myvar` that will expand to both
+specified path segments.
 
 Path segments appearing in variable assignments need to be separated by
 whitespace characters. The path values cannot contain whitespace themselves.
@@ -81,6 +96,8 @@ While the following are invalid:
 
 === Configuration File Locations
 
+*/usr/share/permissions/variables.conf*:: contains variable expansion definitions.
+
 The `permctl` program, when run in `--system` mode, will assemble a set of
 configuration entries depending on the profiles configured in
 __/etc/sysconfig/security__. The order of files parsed (with increasing
@@ -93,7 +110,7 @@ priority) is as follows:
 
 === Available Predefined Profiles
 
-The permissions package ships the following predefines profiles:
+The permissions package ships the following predefined profiles:
 
 *easy*:: security settings targeted towards single user workstations, where
   the only user is also the administrator. This profile is tailored towards more
@@ -129,6 +146,26 @@ following paths, if existing:
  /lib64/prog_v1/libsomething.so
  /lib/prog_v2/libsomething.so
  /lib64/prog_v2/libsomething.so
+
+The following example shows the effect of the `:package:` directive:
+
+----
+# this entry will always be applied regardless of which package owns 'some_program'.
+/usr/bin/some_program root:root 04755
+
+:package: sudo
+# this entry will only be applied if /usr/bin/sudo is owned by the "sudo" package.
+/usr/bin/sudo root:root 04755
+
+# this entry would also be applied only if owned by the "sudo" package, since
+# no new ":package:" directive appeared.
+/usr/bin/another_program root:root 04755
+
+:package: su
+# with the new package directive this entry will only be applied if
+# /usr/bin/su is owned by the "su" package.
+/usr/bin/su root:root 04755
+----
 
 FILES
 -----

--- a/meson.build
+++ b/meson.build
@@ -74,5 +74,5 @@ install_data(sources: 'etc/sysconfig.security', install_dir: 'share/fillup-templ
 install_data(sources: 'zypper-plugin/permissions.py', install_dir: 'lib/zypp/plugins/commit')
 install_data(sources: ['etc/variables.conf', 'etc/permissions', 'profiles/permissions.easy', 'profiles/permissions.secure', 'profiles/permissions.paranoid'], install_dir: 'share/permissions')
 install_data(sources: 'etc/permissions.local', install_dir: '/etc')
-install_subdir('permissions.d', install_dir: 'share/permissions')
+install_emptydir('share/permissions/permissions.d')
 install_data(sources: 'rpm_macros/macros.permissions', install_dir: 'lib/rpm/macros.d')

--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -1,8 +1,6 @@
+# Copyright (c) 2026 SUSE Software Solutions Germany GmbH
 #
-# Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
-#
-# Author: Roman Drahtmueller <draht@suse.de>, 2001
-#
+# Maintainer: SUSE security team <security@suse.de>
 #
 # See /usr/share/permissions/permissions for general hints on how to use this
 # file.

--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -2,15 +2,14 @@
 #
 # Maintainer: SUSE security team <security@suse.de>
 #
-# See /usr/share/permissions/permissions for general hints on how to use this
-# file.
+# See "man permissions(5)" for more information on permissions configuration
+# files.
 #
-# /usr/share/permissions/permissions.easy is set up for the use in a
-# standalone and single-user installation to make things "work" out-of-the box.
-# Some of the settings might be considered somewhat lax from the security
-# standpoint. These aspects are handled differently in the permissions.secure
-# file.
-#
+# The "easy" profile is set up for the use in a standalone and single-user
+# installation to provide a good user experience when multi-user scenarios are
+# not a concern. Some of the settings might be considered somewhat lax from a
+# security standpoint. These aspects are handled differently in the
+# "secure" profile.
 
 #
 # /etc

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -2,17 +2,14 @@
 #
 # Maintainer: SUSE security team <security@suse.de>
 #
-# See /usr/share/permissions/permissions for general hints on how to use
-# this file.
+# See "man permissions(5)" for more information on permissions configuration
+# files.
 #
-# /usr/share/permissions/permissions.paranoid is NOT designed to be used
-# in a single-user as well as a multi-user installation, be it networked
-# or not.
-#
-# Derived from /etc/permissions.secure, it has _all_ sgid and suid bits
-# cleared - therefore, the system is probably not useable for non-privileged
-# users except for simple tasks like changing passwords and such. In addition,
-# some of the configuration files are not readable for world any more.
+# The "paranoid" profile is NOT intended to be used as is, since it will
+# disable _all_ setuid, setgid and capability bits from binaries. This will
+# likely break various use cases. The profile is intended for customization
+# via the permissions.local file to selectively assign a few privileges to
+# necessary programs but drop all the rest.
 #
 # Feel free to use this file as a basis of a system configuration that meets
 # your understanding of "secure", for the case that you're a bit paranoid.
@@ -21,12 +18,6 @@
 # is needed to have a system running flawlessly when users are present.
 # In particular, all terminal emulators will not be able to write to utmp
 # and wtmp any more, which renders who(1) and finger(1) useless.
-#
-# Please always keep in mind that your system listens on network sockets
-# in the default configuration. Change this by disabling the services that
-# you do not need or by restricting access to them using packet filters
-# or tcp wrappers (see hosts_access(5)) to gain a higher level of security
-# in your system.
 
 #
 # /etc

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -1,9 +1,6 @@
-# /usr/share/permissions/permissions.paranoid
+# Copyright (c) 2026 SUSE Software Solutions Germany GmbH
 #
-# Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
-#
-# Author: Roman Drahtmueller <draht@suse.de>, 2001
-#
+# Maintainer: SUSE security team <security@suse.de>
 #
 # See /usr/share/permissions/permissions for general hints on how to use
 # this file.

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -2,53 +2,12 @@
 #
 # Maintainer: SUSE security team <security@suse.de>
 #
-# See /usr/share/permissions/permissions for general hints on how to use
-# this file.
+# See "man permissions(5)" for more information on permissions configuration
+# files.
 #
-# /usr/share/permissions/permissions.secure is designed for the use in a
-# multi-user and networked installation. Most privileged file modes are
-# disabled here. Many programs that still have their suid- or sgid-modes
-# have had their security problems in the past already.
-# The primary target of this configuration is to make the basic things
-# such as changing passwords, the basic networking programs as well as
-# some of the all-day work programs properly function for the unprivileged
-# user. The dial-out packages are executable for users belonging to the
-# "dialout" group - therefore, these users are to be treated "privileged".
-# Packages such as (remote-) batch queueing systems, games, programs for
-# the linux text console, everything linked against OOP libraries and
-# most other exotic utilities are turned into unprivileged binary files
-# in order for them not to cause any security problems if one or more of
-# the programs turn out to have buffer overruns or otherwise locally
-# exploitable programming errors.
-# This file is not designed to make your system as closed and as restrictive
-# as at all possible. In many cases, restricted access to a configuration
-# file is of no use since the data used can be obtained from the /proc file
-# system or interface configuration as well. Also, system programs such as
-# /sbin/ifconfig or /sbin/route are not changed because nosey users can
-# bring their own. "Security by obscurity" will not add any significant
-# security-related advantage to the system. Keep in mind that curiosity
-# is a major motivation for your users to try to see behind the curtain.
-#
-# If you need the functionality of a program that usually runs as a
-# privileged user, then use it as root, or, if you are not root, ask your
-# system administrator for advice. In many cases, adding a user to the
-# "trusted" group gives her access to the resources that are not accessible
-# any more if the admin chose to select "secure" as the permissions default.
-#
-# Please make use of the diff program to see the differences between the
-# permissions.easy and permissions.secure files if things don't work as
-# they should and you suspect a permission or privilege problem.
-# The word "easy" is a reference for the /etc/permissions.easy file.
-#
-# As usual, these settings are "suggested". If you feel so inclined,
-# please feel free to change the modes in this files, but keep a log
-# of your changes for future reference.
-
-# Please always keep in mind that your system listens on network sockets
-# in the default configuration. Change this by disabling the services that
-# you do not need or by restricting access to them using packet filters
-# or tcp wrappers (see hosts_access(5)) to gain a higher level of security
-# in your system.
+# The "secure" profile is designed for the use in multi-user installations or
+# for users that are willing to trade-off some usability for increased
+# security.
 
 #
 # /etc

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -1,9 +1,6 @@
-# /usr/share/permissions/permissions.secure
+# Copyright (c) 2026 SUSE Software Solutions Germany GmbH
 #
-# Copyright (c) 2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
-#
-# Author: Roman Drahtmueller <draht@suse.de>, 2001
-#
+# Maintainer: SUSE security team <security@suse.de>
 #
 # See /usr/share/permissions/permissions for general hints on how to use
 # this file.

--- a/src/entryproc.h
+++ b/src/entryproc.h
@@ -106,6 +106,9 @@ protected: // functions
         return m_need_fix_perms || m_need_fix_caps || m_need_fix_ownership || m_need_fix_acl;
     }
 
+    /// Checks whether the file belongs to one of the packages defined in the entry.
+    bool matchingPkg() const;
+
 protected: // data
 
     uid_t m_file_uid = (uid_t)-1; ///< The resolved user-id corresponding to the active ProfileEntry.

--- a/src/utility.h
+++ b/src/utility.h
@@ -92,6 +92,13 @@ bool matchesAny(const T &val, const SEQ &seq) {
 /// Splits up the `input` string into whitespace separated words and stores them in `words`.
 void splitWords(const std::string &input, std::vector<std::string> &words);
 
+/// Variant of splitWords() which returns the result by value.
+inline std::vector<std::string> splitWords(const std::string &input) {
+    std::vector<std::string> ret;
+    splitWords(input, ret);
+    return ret;
+}
+
 template <typename T>
 bool stringToUnsigned(const std::string &s, T &out, const int base = 10) {
     char *end = nullptr;

--- a/src/utility.h
+++ b/src/utility.h
@@ -110,6 +110,19 @@ bool stringToUnsigned(const std::string &s, T &out, const int base = 10) {
     return true;
 }
 
+/// Create a child process executing `cmdline` and return its stdout as a std::string.
+/**
+ * This function forks and executes the given command line without going
+ * through the shell. `cmdline[0]` is used as the executable name, which can
+ * be a full path or a basename. In the latter case a lookup of the executable
+ * through the PATH environment variable will be performed.
+ *
+ * If a non-zero exit status is returned by the child process then an `int` is
+ * thrown containing the status code.
+ * On other errors a std::runtime_error is thrown.
+ **/
+std::string getSubprocessOutput(const std::vector<std::string> &cmdline);
+
 /// Helper class that wraps a plain POSIX file descriptor.
 /**
  * This wrapper takes care of closing the file descriptor upon destruction


### PR DESCRIPTION
This is the first stage of implementing coupling of permissions entries to package names as per [bsc#1226943](https://bugzilla.suse.com/show_bug.cgi?id=1226943).

With this change `permctl` gains support for a new `:package: <pkg>[,<pkg>] # <comment>` syntax which will restrict all following entries to the given package names, until a new `:package:` directive is encountered.

The topic of the new syntax is a bit awkward. The existing syntax is non-standard and feels old school and hacky. Extending this with something like `package = <pkg>[,<pkg>]` felt like a mismatch in style here, which is why I went for this approach, which makes it clear that this is non-standard parsing.

As long as no occurrences of the new syntax appear in a permissions profile, nothing will change in behaviour. When there are no package restrictions around then no verification of file ownership is made.

As soon as the new `permctl` with this feature is available in Factory we can start migrating the existing profiles. Ideally all entries of all profiles will be converted to be tied to packages. Should some remain for which this doesn't work then they can appear at the top, before any `:package` statement is placed, to have them unrestricted.

`permissions.d` drop-in configuration files also stay unaffected by this as long as the new syntax is not introduced in them individually. Here an additional feature could be included at a later time, which checks the package ownership of the permissions.d drop-in configuration file and implicitly assumes that all the entries contained in the drop-in configuration file should be restricted to the package which also owns the drop-in configuration file. This does not work for all drop-in configuration files currently in existence, though (some refer to files owned by other packages), which is why adjustment of some of them will still be needed.