### PR TITLE
Cleanup no Longer Packaged Entries

### DIFF
--- a/etc/permissions
+++ b/etc/permissions
@@ -35,9 +35,6 @@
 # the same file paths in different packages (popular example:
 # sendmail and postfix, path /usr/sbin/sendmail).
 
-# utempter
-/usr/libexec/utempter/utempter                          root:utmp         2755
-
 # ceph log directory (bsc#1150366)
 /var/log/ceph/                                          ceph:ceph         3770
 

--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -45,7 +45,6 @@
 # needs setuid root when using shadow via NIS:
 # #216816
 /usr/sbin/unix_chkpwd                                   root:shadow       4755
-/usr/sbin/unix2_chkpwd                                  root:shadow       4755
 
 # squid changes from bnc#891268
 # - adjusted paths in bsc#1171569

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -63,7 +63,6 @@
 # needs setuid root when using shadow via NIS:
 # #216816
 /usr/sbin/unix_chkpwd                                   root:shadow       0755
-/usr/sbin/unix2_chkpwd                                  root:shadow       0755
 
 # squid changes from bnc#891268
 # - adjusted paths in bsc#1171569

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -87,7 +87,6 @@
 # needs setuid root when using shadow via NIS:
 # #216816
 /usr/sbin/unix_chkpwd                                   root:shadow       4755
-/usr/sbin/unix2_chkpwd                                  root:shadow       4755
 
 # squid changes from bnc#891268
 # - adjusted paths in bsc#1171569


### PR DESCRIPTION
I went through our whitelisting checker output and these two entries are no longer packaged related to the various changed in shadow and account managment etc.