### PR TITLE
Improve Robustness in Parsing package-coupling Directives

### DIFF
--- a/src/profparser.h
+++ b/src/profparser.h
@@ -89,7 +89,7 @@ protected: // functions
     void parseExtraLine(const std::string &line);
 
     /// Parses a ":package:" specification line as found in permission profiles.
-    void parsePackageLine(const std::string &line);
+    void parsePackageLine(std::string line);
 
     /// Parses extra "+capabilities" lines in permission profiles.
     /**

--- a/tests/base.py
+++ b/tests/base.py
@@ -1257,6 +1257,19 @@ class TestBase:
         if line.find("LeakSanitizer: detected memory leaks") != -1:
             self.printError("ASAN found memory leaks!")
 
+    def scanPermctlOutputForErrors(self, output):
+
+        package_errors = (
+            "bad :package:",
+            "missing package list",
+            "unexpected field encountered")
+
+        for line in output:
+            self._checkForASANErrors(line)
+            for err in package_errors:
+                if line.find(err) != -1:
+                    self.printError(f"encountered package line parsing error: {line}")
+
     def addRpmDbEntry(self, pkg, path):
         with open("/var/lib/rpm/Packages.db", 'a') as rpmdb:
             rpmdb.write(f"{pkg} {path}\n")

--- a/tests/base.py
+++ b/tests/base.py
@@ -1256,7 +1256,6 @@ class TestBase:
     def _checkForASANErrors(self, line):
         if line.find("LeakSanitizer: detected memory leaks") != -1:
             self.printError("ASAN found memory leaks!")
-            self.errors += 1
 
     def addRpmDbEntry(self, pkg, path):
         with open("/var/lib/rpm/Packages.db", 'a') as rpmdb:


### PR DESCRIPTION
It turns out that I introduced syntax errors in commit 1c352fba where I added two lines of the style:

```
:package: first, second # comment
```

The current parsing logic chokes on the space after the comma. This should not be, thus be more forgiving in parsing the syntax.