### PR TITLE
profiles: drop nfs-utils rmtab entry

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -20,9 +20,6 @@
 :package: netcfg
 /etc/exports                                            root:root          644
 
-:package: nfs-kernel-server # from nfs-utils
-/var/lib/nfs/rmtab                                      root:root          644
-
 :package: syslogd
 /etc/syslog.conf                                        root:root          644
 

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -28,9 +28,6 @@
 :package: netcfg
 /etc/exports                                            root:root          600
 
-:package: nfs-kernel-server # from nfs-utils
-/var/lib/nfs/rmtab                                      root:root          600
-
 :package: syslogd
 /etc/syslog.conf                                        root:root          600
 

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -18,9 +18,6 @@
 :package: netcfg
 /etc/exports                                            root:root          644
 
-:package: nfs-kernel-server # from nfs-utils
-/var/lib/nfs/rmtab                                      root:root          644
-
 :package: syslogd
 /etc/syslog.conf                                        root:root          600
 


### PR DESCRIPTION
This path is no longer packages in nfs-kernel-server and is now created via systemd-tmpfiles. See OBS sr#1336168.