### PR TITLE
iputils: Fix capability permissions for clockdiff

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -84,7 +84,7 @@
 
 :package: iputils # needs privileged socket access
 /usr/bin/clockdiff                                      root:root         0755
- +capabilities cap_net_raw=p
+ +capabilities cap_net_raw,cap_sys_nice=ep
 :package: mtr
 /usr/sbin/mtr-packet                                    root:root         0755
  +capabilities cap_net_raw=ep

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -83,7 +83,7 @@
 
 :package: iputils # needs privileged socket access
 /usr/bin/clockdiff                                      root:root         0755
- +capabilities cap_net_raw=p
+ +capabilities cap_net_raw,cap_sys_nice=ep
 :package: mtr
 /usr/sbin/mtr-packet                                    root:root         0755
 


### PR DESCRIPTION
`clockdiff` needs also CAP_SYS_NICE.

Reported-by: Thorsten Kukuk <kukuk@suse.com>
Fixes: boo#1264542
Fixes: 5da6a81 ("iputils: Add capability permissions for clockdiff")