### PR TITLE
profiles: drop netcfg /etc/exports

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -17,9 +17,6 @@
 # files not owned by any package
 /etc/fstab                                              root:root          644
 
-:package: netcfg
-/etc/exports                                            root:root          644
-
 :package: syslogd
 /etc/syslog.conf                                        root:root          644
 

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -25,9 +25,6 @@
 # files not owned by any package
 /etc/fstab                                              root:root          600
 
-:package: netcfg
-/etc/exports                                            root:root          600
-
 :package: syslogd
 /etc/syslog.conf                                        root:root          600
 

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -15,9 +15,6 @@
 # files not owned by any package
 /etc/fstab                                              root:root          644
 
-:package: netcfg
-/etc/exports                                            root:root          644
-
 :package: syslogd
 /etc/syslog.conf                                        root:root          600
 


### PR DESCRIPTION
The netcfg package currently generates the following rpmlint diagnostics:

netcfg.noarch: W: permissions-missing-verifyscript missing %verify_permissions -e /etc/exports
netcfg.noarch: E: permissions-missing-requires missing 'permissions' in PreReq
netcfg.noarch: E: permissions-missing-postin (Badness: 10) missing %set_permissions /etc/exports in %post

This means the package is not invoking permctl at all, rendering the profiles settings ineffective. The original idea of this entry probably was to harden /etc/exports to prevent leakage of plaintext passwords used with NFS shares. This should not be used these days anyway.

The current rpmlint submission will raise badness for permissions-missing-postin to 10,000, thus breaking the netcfg build. I guess the best approach is to drop these entries to avoid any issues.