### PR TITLE
Make iuucp work even with latest chkstat (bsc#1273735)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -119,8 +119,8 @@
 /usr/libexec/mgetty+sendfax/faxq-helper                 fax:root          4755
 /var/spool/fax/outgoing/                                fax:root          0755
 
-:package: uucp
-/var/spool/uucppublic/                                  root:root         1777
+:package: uucp # bsc#1273735
+/var/spool/uucppublic/                                  uucp:uucp         1777
 /usr/bin/uucp                                           uucp:uucp         6555
 /usr/bin/uuname                                         uucp:uucp         6555
 /usr/bin/uustat                                         uucp:uucp         6555

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -126,8 +126,8 @@
 /usr/libexec/mgetty+sendfax/faxq-helper                 fax:root          0755
 /var/spool/fax/outgoing/                                fax:trusted       0755
 
-:package: uucp
-/var/spool/uucppublic/                                  root:uucp         1770
+:package: uucp # bsc#1273735
+/var/spool/uucppublic/                                  uucp:uucp         1770
 /usr/bin/uucp                                           uucp:uucp         0555
 /usr/bin/uuname                                         uucp:uucp         0555
 /usr/bin/uustat                                         uucp:uucp         0555

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -117,8 +117,8 @@
 /usr/libexec/mgetty+sendfax/faxq-helper                 fax:trusted       4750
 /var/spool/fax/outgoing/                                fax:root          0755
 
-:package: uucp
-/var/spool/uucppublic/                                  root:uucp         1770
+:package: uucp # bsc#1273735
+/var/spool/uucppublic/                                  uucp:uucp         1770
 /usr/bin/uucp                                           uucp:uucp         6555
 /usr/bin/uuname                                         uucp:uucp         6555
 /usr/bin/uustat                                         uucp:uucp         6555


### PR DESCRIPTION
The latest chkstat throws an error for root:uucp with 1770 or similar