### PR TITLE
profiles: whitelist selinux-sandbox seunshare (bsc#1268256)

### DIFF
--- a/profiles/permissions.easy
+++ b/profiles/permissions.easy
@@ -318,3 +318,6 @@
 
 # nvidia-modprobe (bsc#1230950)
 /usr/bin/nvidia-modprobe                                root:root 4755
+
+# selinux-sandbox (bsc#1268256)
+/usr/bin/seunshare                                      root:wheel 4750

--- a/profiles/permissions.paranoid
+++ b/profiles/permissions.paranoid
@@ -322,3 +322,6 @@
 
 # nvidia-modprobe (bsc#1230950)
 /usr/bin/nvidia-modprobe                                root:root 0755
+
+# selinux-sandbox (bsc#1268256)
+/usr/bin/seunshare                                      root:root 0755

--- a/profiles/permissions.secure
+++ b/profiles/permissions.secure
@@ -357,3 +357,6 @@
 
 # nvidia-modprobe (bsc#1230950)
 /usr/bin/nvidia-modprobe                                root:root 4755
+
+# selinux-sandbox (bsc#1268256)
+/usr/bin/seunshare                                      root:wheel 4750


### PR DESCRIPTION
Not a clean cherry pick since we don't have `:package:` syntax on slfo-main yet.

SELinux people need this in Leap16.1 as well, thus this backport.