### PR TITLE
profiles: add cacti-spine cap_net_raw (bsc#1273300)

### DIFF
--- a/permissions.easy
+++ b/permissions.easy
@@ -491,3 +491,7 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 2755
+
+# cacti-spine (bsc#1273300)
+/usr/bin/spine                                          root:root 0755
+ +capabilities cap_net_raw=ep

--- a/permissions.paranoid
+++ b/permissions.paranoid
@@ -492,3 +492,6 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 0755
+
+# cacti-spine (bsc#1273300)
+/usr/bin/spine                                          root:root 0755

--- a/permissions.secure
+++ b/permissions.secure
@@ -527,3 +527,7 @@
 
 # postfix (bsc#1201385)
 /usr/sbin/postlog                                       root:maildrop 2755
+
+# cacti-spine (bsc#1273300)
+/usr/bin/spine                                          root:root 0755
+ +capabilities cap_net_raw=ep


### PR DESCRIPTION
This is a manual backport of commit a2d7f0d96fcb from the master branch.